### PR TITLE
[codex] Add one-line installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ Most token waste comes from oversized context, repeated memory, noisy logs, and 
 
 ## 30-Second Install
 
-Pick your tool, copy the matching file into your repository, and commit it.
+Install the right instruction file into the current repository:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/scripts/install-token-efficiency.sh | sh -s -- codex
+```
+
+Replace `codex` with `claude`, `gemini`, `copilot`, or `cursor`. Existing files are not overwritten unless you pass `--force`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/scripts/install-token-efficiency.sh | sh -s -- cursor --force
+```
+
+Manual copy is also supported:
 
 | Tool | Copy this file |
 | --- | --- |
@@ -56,7 +68,8 @@ Ready-to-copy instruction files and supporting material:
 │   ├── bad-vs-good-context.md
 │   └── case-study-ci-log-triage.md
 ├── scripts/
-│   └── check-token-hygiene.sh
+│   ├── check-token-hygiene.sh
+│   └── install-token-efficiency.sh
 └── checklists/
     └── token-efficiency-checklist.md
 ```

--- a/scripts/install-token-efficiency.sh
+++ b/scripts/install-token-efficiency.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+set -eu
+
+TOOL="${1:-}"
+FORCE="false"
+
+if [ "$TOOL" = "--help" ] || [ "$TOOL" = "-h" ] || [ -z "$TOOL" ]; then
+  cat <<'USAGE'
+Usage: sh scripts/install-token-efficiency.sh <tool> [--force]
+
+Tools:
+  claude   -> CLAUDE.md
+  codex    -> AGENTS.md
+  gemini   -> GEMINI.md
+  copilot  -> .github/copilot-instructions.md
+  cursor   -> .cursor/rules/token-efficiency.mdc
+
+Examples:
+  sh scripts/install-token-efficiency.sh codex
+  sh scripts/install-token-efficiency.sh cursor --force
+USAGE
+  exit 0
+fi
+
+if [ "${2:-}" = "--force" ]; then
+  FORCE="true"
+fi
+
+case "$TOOL" in
+  claude)
+    SOURCE_URL="https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/CLAUDE.md"
+    DEST="CLAUDE.md"
+    ;;
+  codex)
+    SOURCE_URL="https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/AGENTS.md"
+    DEST="AGENTS.md"
+    ;;
+  gemini)
+    SOURCE_URL="https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/GEMINI.md"
+    DEST="GEMINI.md"
+    ;;
+  copilot)
+    SOURCE_URL="https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/.github/copilot-instructions.md"
+    DEST=".github/copilot-instructions.md"
+    ;;
+  cursor)
+    SOURCE_URL="https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/.cursor/rules/token-efficiency.mdc"
+    DEST=".cursor/rules/token-efficiency.mdc"
+    ;;
+  *)
+    echo "Unknown tool: $TOOL" >&2
+    echo "Supported: claude, codex, gemini, copilot, cursor" >&2
+    exit 2
+    ;;
+esac
+
+if [ -e "$DEST" ] && [ "$FORCE" != "true" ]; then
+  echo "Refusing to overwrite existing file: $DEST" >&2
+  echo "Re-run with --force if you want to replace it." >&2
+  exit 3
+fi
+
+mkdir -p "$(dirname "$DEST")"
+
+tmp_file="$(mktemp)"
+if command -v curl >/dev/null 2>&1; then
+  curl -fsSL "$SOURCE_URL" -o "$tmp_file"
+elif command -v wget >/dev/null 2>&1; then
+  wget -qO "$tmp_file" "$SOURCE_URL"
+else
+  echo "curl or wget is required." >&2
+  rm -f "$tmp_file"
+  exit 4
+fi
+
+mv "$tmp_file" "$DEST"
+echo "Installed Token Efficiency instructions for $TOOL at $DEST"


### PR DESCRIPTION
## Summary

Adds a one-line installer script that installs the correct Token Efficiency instruction file for Claude, Codex, Gemini, Copilot, or Cursor.

## What changed

- Added `scripts/install-token-efficiency.sh`
- Refuses to overwrite existing files unless `--force` is passed
- Updated the README 30-second install section with `curl | sh` examples

## Validation

Not run locally because direct repository checkout is blocked in this environment.

Closes #7