### PR TITLE
[codex] Add token hygiene CI workflow

### DIFF
--- a/.github/workflows/token-hygiene.yml
+++ b/.github/workflows/token-hygiene.yml
@@ -1,0 +1,22 @@
+name: Token hygiene
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  token-hygiene:
+    name: Run token hygiene check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run token hygiene script
+        run: bash scripts/check-token-hygiene.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Token Efficiency Playbook
 
+[![Token hygiene](https://github.com/ravinperera/ai-token-efficiency-playbook/actions/workflows/token-hygiene.yml/badge.svg)](https://github.com/ravinperera/ai-token-efficiency-playbook/actions/workflows/token-hygiene.yml)
+
 Drop-in instructions, prompts, examples, and lightweight checks to reduce wasted AI tokens across Codex, Claude Code, GitHub Copilot, Cursor, Gemini, and other AI coding agents.
 
 This project is not just about making AI replies shorter. The main thesis is:


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that dogfoods the repo's token hygiene script.

## What changed

- Added `.github/workflows/token-hygiene.yml`
- Runs on pull requests and pushes to `main`
- Added a README status badge

## Validation

Not run locally because direct repository checkout is blocked in this environment.

Closes #8