### PR TITLE
[codex] Add token counter helper

### DIFF
--- a/examples/case-study-template.md
+++ b/examples/case-study-template.md
@@ -1,0 +1,64 @@
+# Case Study Template
+
+Use this template when submitting measured before/after examples.
+
+## Scenario
+
+Describe the task and why token waste appeared.
+
+## Before
+
+### Prompt Shape
+
+```text
+Paste or summarise the original prompt shape here.
+```
+
+### Approximate Input Size
+
+```bash
+python3 scripts/count-tokens.py before-prompt.txt
+```
+
+| Item | Approximate tokens |
+| --- | ---: |
+| Prompt/context | TODO |
+| Total | TODO |
+
+## After
+
+### TokenSaver Prompt
+
+```text
+Paste the reduced prompt shape here.
+```
+
+### Approximate Input Size
+
+```bash
+python3 scripts/count-tokens.py after-prompt.txt
+```
+
+| Item | Approximate tokens |
+| --- | ---: |
+| Prompt/context | TODO |
+| Total | TODO |
+
+## Result
+
+| Metric | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| Approximate input tokens | TODO | TODO | TODO |
+| Correctness retained | TODO | TODO | TODO |
+
+## Measurement Method
+
+Record:
+
+- tool and model
+- tokenizer or approximation used
+- commands used to count tokens
+- whether follow-up prompts were needed
+- caveats that could affect the numbers
+
+Do not make fixed-percentage claims. Savings depend on task, tool, model, and loaded context.

--- a/scripts/count-tokens.py
+++ b/scripts/count-tokens.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Count tokens for a file or stdin.
+
+Uses tiktoken when installed. Falls back to a documented approximation when it
+is not available, so the script remains useful in lightweight environments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def read_input(path: str | None) -> str:
+    if path and path != "-":
+        return Path(path).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def approximate_tokens(text: str) -> int:
+    # Rough approximation: words/punctuation plus a small allowance for spacing.
+    # This is not model-exact, but is stable enough for before/after comparison.
+    pieces = re.findall(r"\w+|[^\w\s]", text, flags=re.UNICODE)
+    return max(1, int(len(pieces) * 1.15)) if text else 0
+
+
+def tiktoken_count(text: str, encoding_name: str) -> int | None:
+    try:
+        import tiktoken  # type: ignore
+    except Exception:
+        return None
+
+    encoding = tiktoken.get_encoding(encoding_name)
+    return len(encoding.encode(text))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Count tokens for a file or stdin.")
+    parser.add_argument("path", nargs="?", help="File to count. Use '-' or omit for stdin.")
+    parser.add_argument(
+        "--encoding",
+        default="cl100k_base",
+        help="tiktoken encoding to use when tiktoken is installed. Default: cl100k_base",
+    )
+    parser.add_argument(
+        "--approx-only",
+        action="store_true",
+        help="Skip tiktoken and use the deterministic approximation.",
+    )
+    args = parser.parse_args()
+
+    text = read_input(args.path)
+    count = None if args.approx_only else tiktoken_count(text, args.encoding)
+    method = "tiktoken" if count is not None else "approximation"
+
+    if count is None:
+        count = approximate_tokens(text)
+
+    source = args.path or "stdin"
+    print(f"{count}\t{method}\t{source}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a small token counter helper and a reusable case-study template for reproducible before/after numbers.

## What changed

- Added `scripts/count-tokens.py`
- Uses `tiktoken` when available
- Falls back to a documented approximation
- Added `examples/case-study-template.md`

## Validation

Script reviewed for syntax. Not run locally because direct repository checkout is blocked in this environment.

Closes #10