### PR TITLE
[codex] Add markdown lint and link check CI

### DIFF
--- a/.github/workflows/markdown-quality.yml
+++ b/.github/workflows/markdown-quality.yml
@@ -1,0 +1,38 @@
+name: Markdown quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-lint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: "**/*.md"
+
+  link-check:
+    name: Link check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run lychee link checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --verbose --no-progress "**/*.md"
+          fail: true

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,9 @@
+config:
+  MD013: false
+  MD033: false
+  MD041: false
+globs:
+  - "**/*.md"
+ignores:
+  - "node_modules/**"
+  - ".git/**"


### PR DESCRIPTION
## Summary

Adds markdown linting and link checking on PRs and pushes to `main`.

## What changed

- Added `.github/workflows/markdown-quality.yml`
- Added `.markdownlint-cli2.yaml`
- Runs markdownlint-cli2 and lychee

## Validation

Not run locally because direct repository checkout is blocked in this environment.

Closes #11