### PR TITLE
[codex] Add contribution templates and CODEOWNERS

### DIFF
--- a/.github/ISSUE_TEMPLATE/case-study-submission.yml
+++ b/.github/ISSUE_TEMPLATE/case-study-submission.yml
@@ -1,0 +1,44 @@
+name: Case study submission
+description: Submit a measured before/after token-efficiency case study
+title: "Case study: <workflow>"
+labels:
+  - case-study
+body:
+  - type: input
+    id: workflow
+    attributes:
+      label: Workflow
+      description: What task or workflow did you measure?
+      placeholder: Example: Terraform plan debugging
+    validations:
+      required: true
+  - type: textarea
+    id: before
+    attributes:
+      label: Before context
+      description: Summarise the original prompt/context shape and token count.
+    validations:
+      required: true
+  - type: textarea
+    id: after
+    attributes:
+      label: After context
+      description: Summarise the TokenSaver prompt/context shape and token count.
+    validations:
+      required: true
+  - type: textarea
+    id: method
+    attributes:
+      label: Measurement method
+      description: Include tokenizer/tool, model, command, and caveats.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I avoided fixed-percentage claims.
+          required: true
+        - label: I kept enough context to preserve correctness.
+          required: true

--- a/.github/ISSUE_TEMPLATE/new-tool-instruction-file.yml
+++ b/.github/ISSUE_TEMPLATE/new-tool-instruction-file.yml
@@ -1,0 +1,36 @@
+name: New tool instruction file
+description: Request support for another AI tool or agent instruction format
+title: "Add instruction file for <tool>"
+labels:
+  - enhancement
+  - tool-support
+body:
+  - type: input
+    id: tool
+    attributes:
+      label: Tool name
+      description: Name of the AI tool, agent, IDE, or CLI.
+      placeholder: Example: Windsurf
+    validations:
+      required: true
+  - type: input
+    id: target-path
+    attributes:
+      label: Expected instruction path
+      description: Where should the instruction file live in a consuming repo?
+      placeholder: Example: .windsurf/rules/token-efficiency.md
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Tool-specific token waste notes
+      description: What does this tool commonly over-load or repeat?
+      placeholder: Example: It loads broad workspace context unless rules are scoped.
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link official docs or examples if available.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What changed
+
+-
+
+## Why
+
+-
+
+## Checks
+
+- [ ] Kept guidance short and practical
+- [ ] Measured token counts where this is a case study
+- [ ] Avoided fixed-percentage saving claims
+- [ ] Added or updated docs/examples where needed
+- [ ] Ran relevant local checks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ravinperera


### PR DESCRIPTION
## Summary

Adds GitHub templates to guide new tool instruction requests, case-study submissions, and PR reviews.

## What changed

- Added issue template for new tool instruction files
- Added issue template for case study submissions
- Added PR template
- Added `CODEOWNERS` assigning review to `@ravinperera`

## Validation

YAML/Markdown reviewed. Not run locally because direct repository checkout is blocked in this environment.

Closes #12