### PR TITLE
[codex] Add changelog and versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for published instruction-file releases.
+
+## [Unreleased]
+
+### Added
+
+- Placeholder for upcoming improvements.
+
+## [1.0.0] - 2026-06-18
+
+### Added
+
+- Initial AI Token Efficiency Playbook.
+- Tool instruction files for Codex, Claude Code, Gemini, GitHub Copilot, and Cursor.
+- Token-saving principles, context hygiene guidance, CLI-output compression, and model-routing guidance.
+- Token efficiency checklist.
+- Example prompts and first CI log triage case study.
+- Lightweight token hygiene script and pre-commit hook.
+
+[Unreleased]: https://github.com/ravinperera/ai-token-efficiency-playbook/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/ravinperera/ai-token-efficiency-playbook/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

Adds a changelog in Keep a Changelog style and documents the initial `1.0.0` release contents.

## What changed

- Added `CHANGELOG.md`
- Added version comparison/release links

## Note

The actual `v1.0.0` git tag still needs to be created after this is merged, because tag creation is not exposed in the current connector flow.

Closes #13