### PR TITLE
[codex] Add social preview and topic guidance

### DIFF
--- a/docs/social-preview.md
+++ b/docs/social-preview.md
@@ -1,0 +1,42 @@
+# Social Preview And Discovery Settings
+
+GitHub social previews and topics are repository settings, so they must be applied manually by a repository admin.
+
+## Recommended Social Preview Text
+
+```text
+AI Token Efficiency Playbook
+Context hygiene and model routing for cheaper, cleaner AI coding sessions.
+```
+
+## Suggested Banner Layout
+
+- Size: `1280 x 640`
+- Background: dark blue/black gradient
+- Main text: `AI Token Efficiency Playbook`
+- Subtitle: `Context hygiene • model routing • cleaner AI sessions`
+- Small footer: `github.com/ravinperera/ai-token-efficiency-playbook`
+
+## Suggested GitHub Topics
+
+Use concise topics that match how people search:
+
+- `ai`
+- `ai-agents`
+- `coding-agents`
+- `prompt-engineering`
+- `developer-tools`
+- `token-optimization`
+- `context-engineering`
+- `claude-code`
+- `github-copilot`
+- `cursor`
+- `gemini`
+- `codex`
+
+## Manual Steps
+
+1. Open the repository on GitHub.
+2. Go to **Settings**.
+3. In **General**, find **Social preview** and upload the banner.
+4. On the repo main page, edit **About** and add the topics above.


### PR DESCRIPTION
## Summary

Adds guidance for the repo social preview image and GitHub topics.

## What changed

- Added `docs/social-preview.md`
- Includes suggested banner copy, layout, topics, and manual GitHub settings steps

## Note

The actual social preview upload and topic update must be done manually in GitHub repository settings.

Closes #16