### PR TITLE
docs: add token savings measurement template

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Ready-to-copy instruction files and supporting material:
 │   └── case-study-ci-log-triage.md
 ├── scripts/
 │   └── check-token-hygiene.sh
+├── templates/
+│   └── token-savings-measurement.md
 └── checklists/
     └── token-efficiency-checklist.md
 ```
@@ -117,7 +119,7 @@ No. The goal is to remove low-value context, not useful evidence. Accuracy comes
 
 ### How do I measure savings?
 
-Use your AI tool's token dashboard where available, or run the same workflow before and after applying the playbook and compare prompt/context size. Record the tool, model, input shape, output shape, and caveats so the result is reproducible.
+Use your AI tool's token dashboard where available, or run the same workflow before and after applying the playbook and compare prompt/context size. Record the tool, model, input shape, output shape, and caveats so the result is reproducible. Use `templates/token-savings-measurement.md` as a starting point.
 
 ### Is this only for coding agents?
 

--- a/templates/token-savings-measurement.md
+++ b/templates/token-savings-measurement.md
@@ -1,0 +1,66 @@
+# Token Savings Measurement Template
+
+Use this template to record before/after measurements without turning the result into an unsupported benchmark claim.
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Date | YYYY-MM-DD |
+| Repository / project |  |
+| AI tool |  |
+| Model |  |
+| Task type |  |
+| Playbook guidance used |  |
+| Measurement owner |  |
+
+## Baseline Run
+
+Describe the run before applying the token-efficiency guidance.
+
+| Measurement | Value |
+| --- | --- |
+| Prompt / context size |  |
+| Output size |  |
+| Files or logs included |  |
+| Tool calls / searches |  |
+| Time to useful answer |  |
+| Result quality notes |  |
+
+## Improved Run
+
+Describe the run after applying the token-efficiency guidance.
+
+| Measurement | Value |
+| --- | --- |
+| Prompt / context size |  |
+| Output size |  |
+| Files or logs included |  |
+| Tool calls / searches |  |
+| Time to useful answer |  |
+| Result quality notes |  |
+
+## Result
+
+| Outcome | Value |
+| --- | --- |
+| Estimated input reduction |  |
+| Estimated output reduction |  |
+| Accuracy impact |  |
+| Developer experience impact |  |
+| Recommended default |  |
+
+## Caveats
+
+Record anything that could affect repeatability:
+
+- Different model or tool version
+- Different repository state
+- Cached context or memory
+- Non-deterministic output
+- Manual summarisation used
+- Missing token dashboard data
+
+## Notes
+
+Add links to prompts, logs, pull requests, screenshots, or dashboards where available. Avoid publishing sensitive prompts, private code, production logs, credentials, or customer data.


### PR DESCRIPTION
Closes #29

## Summary
- Adds a reproducible token savings measurement template.
- Links the template from the README measurement FAQ.
- Updates the README tree so the new `templates/` directory is visible.

## Notes
- This keeps the project practical without making unsupported fixed-percentage saving claims.
- Documentation-only change; no runtime tests required.