### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+This project contains prompt templates, workflow guidance, measurement templates, and example files. Please avoid sharing sensitive information when opening issues, pull requests, screenshots, logs, or measurement artifacts.
+
+## Reporting a concern
+
+If you find a security concern in this repository, please open a GitHub issue with a minimal description that does not include secrets, private prompts, customer data, production logs, access tokens, API keys, or internal system details.
+
+If the concern requires sensitive detail, share only the high-level impact publicly and arrange a safer private channel with the repository owner before providing evidence.
+
+## Sensitive content guidance
+
+Before contributing examples or measurements, remove or replace:
+
+- API keys, access tokens, credentials, cookies, and session values
+- Customer names, user identifiers, email addresses, and tenant details
+- Private repository names, internal hostnames, database names, and account IDs
+- Production logs, stack traces, prompts, or screenshots containing confidential data
+- Commercially sensitive model usage, cost, or performance data
+
+## Example and template safety
+
+Use synthetic or anonymised examples wherever possible. If a real prompt, log, dashboard, or workflow is needed to explain a pattern, reduce it to the smallest safe excerpt and document any caveats.
+
+## Supported scope
+
+This policy covers security concerns related to the repository content, including prompt guidance, examples, scripts, templates, and documentation. It does not cover vulnerabilities in third-party AI tools, models, cloud services, or editor integrations referenced by the playbook.


### PR DESCRIPTION
Closes #31

## Summary
- Adds a lightweight `SECURITY.md` for responsible reporting.
- Documents how to avoid exposing sensitive prompts, logs, credentials, customer data, and measurement artifacts.

## Notes
- Documentation-only change.