### PR TITLE
ci: add token hygiene workflow

### DIFF
--- a/.github/workflows/token-hygiene.yml
+++ b/.github/workflows/token-hygiene.yml
@@ -1,0 +1,22 @@
+name: Token hygiene
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  token-hygiene:
+    name: Run token hygiene checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run token hygiene script
+        run: bash scripts/check-token-hygiene.sh


### PR DESCRIPTION
## Summary
- Add a lightweight GitHub Actions workflow for token hygiene checks
- Run the existing `scripts/check-token-hygiene.sh` script on pull requests and pushes to `main`

Closes #33