### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/case-study-submission.md
+++ b/.github/ISSUE_TEMPLATE/case-study-submission.md
@@ -1,0 +1,35 @@
+---
+name: Case study submission
+description: Propose a measured before/after token-efficiency example
+title: "Case study: <workflow>"
+labels: [case-study, documentation]
+---
+
+## Workflow
+
+What task or workflow did you measure?
+
+## Before
+
+Describe the original prompt/context shape. Include the tool, model, rough file/log size, and what made the context noisy.
+
+## After
+
+Describe what changed. For example: smaller file ranges, summarised logs, better handoff, model routing, or reusable templates.
+
+## Measurement
+
+Use `templates/token-savings-measurement.md` where possible.
+
+- Tool:
+- Model:
+- Input/context before:
+- Input/context after:
+- Output quality impact:
+- Caveats:
+
+## Evidence
+
+- [ ] No sensitive prompts, logs, customer data, or secrets are included.
+- [ ] The case study avoids fixed percentage claims unless the numbers are measured and reproducible.
+- [ ] The example is useful to someone applying the playbook.

--- a/.github/ISSUE_TEMPLATE/new-tool-instruction-file.md
+++ b/.github/ISSUE_TEMPLATE/new-tool-instruction-file.md
@@ -1,0 +1,31 @@
+---
+name: New tool instruction file
+description: Suggest support for another AI tool or coding agent
+title: "Add instruction file for <tool>"
+labels: [documentation, enhancement]
+---
+
+## Tool
+
+Name of the AI tool or coding agent:
+
+## Why it should be supported
+
+Explain who would use it and what token/context problem this instruction file should solve.
+
+## Expected file location
+
+Example: `.github/copilot-instructions.md`, `.cursor/rules/token-efficiency.mdc`, or another tool-specific path.
+
+## Guidance to include
+
+- Context hygiene rules:
+- Model/tool routing notes:
+- Log/output compression notes:
+- Safety or accuracy caveats:
+
+## Validation
+
+- [ ] The instruction file is short and tool-specific.
+- [ ] It links back to the canonical guidance in `guidelines/` where useful.
+- [ ] It avoids fixed percentage token-saving claims unless measured.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+Describe the smallest useful change this PR makes.
+
+## Token-efficiency impact
+
+- [ ] Reduces unnecessary context, repeated instructions, noisy logs, or unclear model/tool routing.
+- [ ] Keeps accuracy, evidence, and safety more important than making prompts shorter.
+- [ ] Avoids fixed percentage token-saving claims unless backed by measured evidence.
+
+## Checks
+
+- [ ] Links to relevant guidance, checklist, template, or example files where useful.
+- [ ] Does not include secrets, private prompts, customer data, or sensitive logs.
+- [ ] Keeps new instructions concise and avoids duplicating canonical guidance unnecessarily.
+- [ ] Ran `bash scripts/check-token-hygiene.sh` or documented why it was not applicable.
+
+Closes #

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default owner for repository changes
+* @ravinperera
+
+# Keep GitHub community health and workflow files reviewed
+.github/ @ravinperera
+.github/workflows/ @ravinperera


### PR DESCRIPTION
## Summary

Adds lightweight GitHub workflow templates for contributors:

- New tool instruction file issue template
- Case study submission issue template
- Pull request checklist template
- CODEOWNERS for default review ownership

## Why

This completes the repository hygiene requested in #12 and makes future contributions easier to scope without duplicating guidance or introducing unsupported token-saving claims.

Closes #12