### PR TITLE
fix: harden token hygiene checks for real filenames

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -39,3 +39,6 @@ jobs:
             -s tests \
             -p 'test_estimate_context_size.py' \
             -v
+
+      - name: Test token hygiene checker
+        run: bash tests/test_check_token_hygiene.sh

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Ready-to-copy instruction files and supporting material:
 │   ├── check-token-hygiene.sh
 │   └── estimate-context-size.py
 ├── tests/
+│   ├── test_check_token_hygiene.sh
 │   └── test_estimate_context_size.py
 ├── templates/
 │   ├── ci-failure-triage.md
@@ -138,13 +139,14 @@ To produce rough before/after context-size numbers for a case study, use the dep
 python3 scripts/estimate-context-size.py before.md after.md --markdown
 ```
 
-Run the estimator regression tests before changing its file discovery, encoding, totals, or output format:
+Run the helper regression tests before changing file discovery, thresholds, encoding, totals, or output formats:
 
 ```bash
 python3 -m unittest discover -s tests -p 'test_estimate_context_size.py' -v
+bash tests/test_check_token_hygiene.sh
 ```
 
-GitHub Actions runs the same dependency-free test suite on pull requests and pushes to `main`.
+The shell suite verifies staged filenames containing spaces, log and context thresholds, instruction-size limits, untracked-file behavior, and the non-Git fallback. GitHub Actions runs both dependency-free suites on pull requests and pushes to `main`.
 
 With pre-commit:
 

--- a/scripts/check-token-hygiene.sh
+++ b/scripts/check-token-hygiene.sh
@@ -56,17 +56,15 @@ check_instruction_file ".github/copilot-instructions.md"
 check_instruction_file ".cursor/rules/token-efficiency.mdc"
 
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  files=$(git diff --cached --name-only --diff-filter=ACM || true)
+  while IFS= read -r -d '' file; do
+    check_large_file "$file"
+  done < <(git diff --cached --name-only --diff-filter=ACM -z)
 else
-  files=$(find . -type f | sed 's#^./##')
+  while IFS= read -r -d '' file; do
+    file="${file#./}"
+    check_large_file "$file"
+  done < <(find . -type f -not -path './.git/*' -print0)
 fi
-
-for file in $files; do
-  case "$file" in
-    .git/*) continue ;;
-  esac
-  check_large_file "$file"
-done
 
 if [ "$failures" -gt 0 ]; then
   echo "token hygiene check failed with $failures issue(s)."

--- a/tests/test_check_token_hygiene.sh
+++ b/tests/test_check_token_hygiene.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CHECK_SCRIPT="$REPO_ROOT/scripts/check-token-hygiene.sh"
+TEMP_DIRS=()
+
+cleanup() {
+  for directory in "${TEMP_DIRS[@]}"; do
+    rm -rf "$directory"
+  done
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+new_repo() {
+  local directory
+  directory=$(mktemp -d)
+  TEMP_DIRS+=("$directory")
+  git -C "$directory" init -q
+  printf '%s' "$directory"
+}
+
+expect_success() {
+  local name="$1"
+  local output
+  shift
+
+  if ! output=$("$@" 2>&1); then
+    fail "$name should pass, output: $output"
+  fi
+}
+
+expect_failure() {
+  local name="$1"
+  local expected="$2"
+  local output
+  shift 2
+
+  if output=$("$@" 2>&1); then
+    fail "$name should fail"
+  fi
+
+  if ! grep -Fq "$expected" <<<"$output"; then
+    fail "$name missing '$expected': $output"
+  fi
+}
+
+repo=$(new_repo)
+printf 'small\n' > "$repo/notes with spaces.md"
+git -C "$repo" add "notes with spaces.md"
+expect_success \
+  "staged filename with spaces" \
+  bash -c "cd '$repo' && MAX_CONTEXT_FILE_KB=4 bash '$CHECK_SCRIPT'"
+
+repo=$(new_repo)
+dd if=/dev/zero of="$repo/build output.log" bs=1024 count=16 status=none
+git -C "$repo" add "build output.log"
+expect_failure \
+  "large staged log with spaces" \
+  "large-log-file: build output.log" \
+  bash -c "cd '$repo' && MAX_LOG_FILE_KB=4 bash '$CHECK_SCRIPT'"
+
+repo=$(new_repo)
+dd if=/dev/zero of="$repo/context.txt" bs=1024 count=16 status=none
+git -C "$repo" add context.txt
+expect_failure \
+  "large staged context" \
+  "large-context-file: context.txt" \
+  bash -c "cd '$repo' && MAX_CONTEXT_FILE_KB=4 bash '$CHECK_SCRIPT'"
+
+repo=$(new_repo)
+printf 'one\ntwo\nthree\n' > "$repo/AGENTS.md"
+expect_failure \
+  "oversized instruction file" \
+  "instruction-too-large: AGENTS.md" \
+  bash -c "cd '$repo' && MAX_INSTRUCTION_LINES=2 bash '$CHECK_SCRIPT'"
+
+repo=$(new_repo)
+dd if=/dev/zero of="$repo/untracked.log" bs=1024 count=16 status=none
+expect_success \
+  "untracked files are outside staged check" \
+  bash -c "cd '$repo' && MAX_LOG_FILE_KB=4 bash '$CHECK_SCRIPT'"
+
+directory=$(mktemp -d)
+TEMP_DIRS+=("$directory")
+dd if=/dev/zero of="$directory/fallback output.trace" bs=1024 count=16 status=none
+expect_failure \
+  "non-git fallback with spaces" \
+  "large-log-file: fallback output.trace" \
+  bash -c "cd '$directory' && MAX_LOG_FILE_KB=4 bash '$CHECK_SCRIPT'"
+
+echo "token hygiene regression tests passed."


### PR DESCRIPTION
Closes #48

## Summary

- replaces whitespace-delimited file iteration with null-delimited Git and `find` input
- preserves staged-file behavior inside Git worktrees and full-file fallback outside Git
- adds a dependency-free shell regression suite
- covers filenames with spaces, staged log and context thresholds, instruction-size limits, untracked-file behavior, and non-Git fallback behavior
- runs the shell suite in the existing helper-script workflow and documents the local command

## Why

The previous `for file in $files` loop split valid paths containing spaces. That could cause a staged file to be skipped or checked under the wrong path. Null-delimited input makes the checker reliable for normal filesystem names.

## Safety

- no production data, credentials, external services, or network calls are used
- tests create temporary local repositories and clean them up automatically
- workflow permissions remain limited to `contents: read`
- existing threshold defaults and staged-file scope remain unchanged

## Validation

- `bash tests/test_check_token_hygiene.sh`
- `python3 -m unittest discover -s tests -p 'test_estimate_context_size.py' -v`