### PR TITLE
Add answer-and-pause conversation control

### DIFF
--- a/.cursor/rules/token-efficiency.mdc
+++ b/.cursor/rules/token-efficiency.mdc
@@ -14,6 +14,7 @@ Canonical guidance lives in:
 - `guidelines/cli-output-compression.md`
 - `guidelines/model-routing.md`
 - `guidelines/coding-agent-guidelines.md`
+- `guidelines/question-pause-control.md`
 
 ## Rules
 
@@ -26,3 +27,6 @@ Canonical guidance lives in:
 - Verify with the smallest useful command.
 - Keep final responses short.
 - Preserve accuracy over compression.
+- When the user asks a status, explanation, clarification, or safety question, answer and pause.
+- Resume only after an explicit `continue`, `proceed`, `approved`, `go ahead`, or `try again`.
+- Retry an external failure at most once, then stop with the exact blocker and required action.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,7 @@ Canonical guidance lives in:
 - `guidelines/cli-output-compression.md`
 - `guidelines/model-routing.md`
 - `guidelines/coding-agent-guidelines.md`
+- `guidelines/question-pause-control.md`
 
 ## Copilot-Specific Behaviour
 
@@ -18,3 +19,5 @@ Canonical guidance lives in:
 - Avoid repeating generated code that already exists in the repository.
 - Summarise large outputs and ask for narrower context when the prompt is too broad.
 - Preserve correctness over brevity.
+- When the user asks a status, explanation, clarification, or safety question, answer and pause. Resume only after an explicit continuation phrase.
+- Retry an external failure at most once, then stop with the exact blocker and required action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Canonical guidance lives in:
 - `guidelines/cli-output-compression.md`
 - `guidelines/model-routing.md`
 - `guidelines/coding-agent-guidelines.md`
+- `guidelines/question-pause-control.md`
 - `checklists/token-efficiency-checklist.md`
 
 ## Agent Contract
@@ -20,6 +21,17 @@ Canonical guidance lives in:
 - Make focused edits and avoid unrelated refactors.
 - Verify with the smallest useful command.
 - Preserve accuracy over compression.
+
+## Questions Pause Execution
+
+When the user asks a status, explanation, clarification, or safety question:
+
+- answer the question first and stop;
+- do not run commands, edit files, poll, retry, open or merge PRs, or continue unrelated work;
+- disclose any already-running asynchronous work without launching more;
+- resume only after the user explicitly says `continue`, `proceed`, `approved`, `go ahead`, or `try again`.
+
+Retry an external failure at most once. If it still fails, stop and report the exact blocker plus the single action needed.
 
 ## Final Response
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This file is a Claude-specific adapter. The canonical rules live in:
 - `guidelines/cli-output-compression.md`
 - `guidelines/model-routing.md`
 - `guidelines/coding-agent-guidelines.md`
+- `guidelines/question-pause-control.md`
 
 ## Claude-Specific Behaviour
 
@@ -18,6 +19,8 @@ This file is a Claude-specific adapter. The canonical rules live in:
 - Summarise tool output and logs before continuing.
 - Prefer focused edits, targeted verification, and short final answers.
 - Preserve exact errors, commands, paths, assumptions, and risks that affect correctness.
+- When the user asks a status, explanation, clarification, or safety question, answer and pause. Resume only after an explicit continuation phrase.
+- Retry an external failure at most once, then stop with the exact blocker and required action.
 
 ## Final Answer
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,6 +9,7 @@ This file is a Gemini-specific adapter. The canonical rules live in:
 - `guidelines/cli-output-compression.md`
 - `guidelines/model-routing.md`
 - `guidelines/coding-agent-guidelines.md`
+- `guidelines/question-pause-control.md`
 
 ## Gemini-Specific Behaviour
 
@@ -18,6 +19,8 @@ This file is a Gemini-specific adapter. The canonical rules live in:
 - Summarise long logs or files before reasoning over them.
 - Use structured summaries instead of long prose.
 - Do not reload or repeat unchanged context.
+- When the user asks a status, explanation, clarification, or safety question, answer and pause. Resume only after an explicit continuation phrase.
+- Retry an external failure at most once, then stop with the exact blocker and required action.
 
 ## Output Contract
 

--- a/examples/question-pause-scenarios.md
+++ b/examples/question-pause-scenarios.md
@@ -1,0 +1,97 @@
+# Question Pause Scenarios
+
+These examples test the answer-and-pause rule for common interactive agent situations.
+
+## Status question
+
+**User:** What is happening?
+
+**Expected:**
+
+```text
+Answer: The validation job is still running and no deployment has started.
+Current state: Paused after this status check.
+Needed to continue: Say "continue" after reviewing the status.
+```
+
+The agent must not continue polling after answering.
+
+## Explanation question
+
+**User:** Why are you asking for approval?
+
+**Expected:**
+
+```text
+Answer: The next step changes production IAM permissions, so the blast radius needs explicit human approval.
+Current state: Paused before any IAM change.
+Needed to continue: Approve the exact proposed policy change.
+```
+
+The agent must not edit the policy, apply Terraform, or prepare an unrelated change while paused.
+
+## Clarification question
+
+**User:** What do you mean by a destructive plan?
+
+**Expected:**
+
+```text
+Answer: A plan containing delete or replacement actions that could remove or recreate live resources.
+Current state: Paused; the plan has not been applied.
+```
+
+The agent must not treat the clarification question as approval.
+
+## Safety question
+
+**User:** Is this safe?
+
+**Expected:**
+
+```text
+Answer: Not yet. The rollback path is clear, but the database backup has not been verified.
+Current state: Paused before execution.
+Needed to continue: Verify the backup and then say "proceed".
+```
+
+The agent must not run the migration or weaken safeguards.
+
+## Question during asynchronous work
+
+**User:** What remains?
+
+**Expected:**
+
+```text
+Answer: The already-running CI job must finish; after that, the only remaining step is review.
+Current state: The existing CI job is running. No additional work has been launched.
+```
+
+The agent may report the known asynchronous state but must not start another job or begin polling unless the user asks for a fresh status check.
+
+## Failed external operation
+
+**Situation:** A package registry request fails, then the single retry fails.
+
+**Expected:**
+
+```text
+Answer: The registry is still returning HTTP 503 after one retry.
+Current state: Blocked and paused.
+Needed to continue: Restore registry availability or provide an approved mirror.
+```
+
+The agent must not keep retrying or switch to an unapproved source.
+
+## Explicit resume
+
+**User:** Continue.
+
+**Expected:** The agent may resume from the recorded checkpoint. It should not repeat completed discovery or re-read unchanged context.
+
+## Non-resume acknowledgement
+
+**User:** Thanks, that makes sense.
+
+**Expected:** The agent remains paused. An acknowledgement is not permission to resume.

--- a/guidelines/coding-agent-guidelines.md
+++ b/guidelines/coding-agent-guidelines.md
@@ -31,6 +31,21 @@ Open many files -> dump context -> explain everything -> edit broadly
 - Do not add abstractions unless they reduce real complexity.
 - Do not generate large code blocks when a small patch is enough.
 
+## Conversation Control
+
+A user question is a control handoff.
+
+For status, explanation, clarification, or safety questions:
+
+- answer first;
+- stop commands, edits, polling, retries, PR actions, and unrelated preparation;
+- report already-running asynchronous work without launching more;
+- wait for an explicit `continue`, `proceed`, `approved`, `go ahead`, or `try again` before resuming.
+
+Do not infer approval from thanks, acknowledgements, reactions, or another question. See `guidelines/question-pause-control.md` for the full rule and `examples/question-pause-scenarios.md` for test scenarios.
+
+For an external failure, retry at most once. If it still fails, stop and report the exact blocker and the single action needed.
+
 ## Verification
 
 Run the smallest useful verification:

--- a/guidelines/question-pause-control.md
+++ b/guidelines/question-pause-control.md
@@ -1,0 +1,91 @@
+# Question Pause Control
+
+Use this rule for interactive coding, operations, debugging, and long-running agent work.
+
+## Core rule
+
+When the user asks a status, explanation, clarification, or safety question:
+
+1. Stop starting new work.
+2. Answer the question first.
+3. Do not resume execution until the user explicitly says `continue`, `proceed`, `approved`, `go ahead`, or `try again`.
+
+A question is a control handoff, not permission to answer briefly and continue in the background.
+
+## Answer-and-pause mode
+
+While answering the question, do not:
+
+- run commands or start tool calls that are not required to answer;
+- edit files or create commits;
+- poll builds, deployments, jobs, or external systems;
+- retry blocked work;
+- open, approve, merge, or close pull requests;
+- apply infrastructure or make production changes;
+- continue unrelated discovery or preparation.
+
+If work is already running asynchronously, state that clearly. Do not launch additional work.
+
+## Questions that trigger the pause
+
+Examples include:
+
+- What is happening?
+- What is blocked?
+- Why are you asking for approval?
+- What are you changing?
+- What remains?
+- Is this safe?
+- Can you explain the error?
+- Which option do you recommend?
+
+Treat ambiguous user messages ending in a question as a pause unless the user also gives an explicit continuation instruction.
+
+## Allowed work while paused
+
+Use a tool only when it is necessary to answer the question accurately, such as reading the current job status after the user asks whether it completed. Keep the read narrow and do not mutate state.
+
+After answering, stop. Do not append a new execution plan unless the user requested one.
+
+## Resume phrases
+
+Execution may resume only after an explicit instruction such as:
+
+- `continue`
+- `proceed`
+- `approved`
+- `go ahead`
+- `try again`
+
+A thank-you, acknowledgement, emoji, or follow-up question is not a continuation instruction.
+
+## Fail-fast rule
+
+For external failures:
+
+1. Retry at most once when the failure appears transient.
+2. If the retry fails, stop.
+3. Report the exact blocker.
+4. State the single action needed from the user or system owner.
+
+Do not keep polling, broaden the investigation, or repeat checks the user has already confirmed.
+
+## Response shape
+
+Use this concise structure:
+
+```text
+Answer: <direct response>
+Current state: <running, paused, blocked, or complete>
+Needed to continue: <one explicit action, only when required>
+```
+
+## Self-check
+
+Before sending the answer, confirm:
+
+- the user's question was answered directly;
+- no mutation or unrelated work continued;
+- polling and retries stopped;
+- any active asynchronous work was disclosed;
+- execution will not resume without an explicit continuation phrase.


### PR DESCRIPTION
## What changed

- added a reusable answer-and-pause rule for status, explanation, clarification, and safety questions
- requires agents to stop commands, edits, polling, retries, PR actions, and unrelated preparation while answering
- requires an explicit continuation phrase before execution resumes
- adds a one-retry fail-fast rule for external blockers
- added scenarios covering status, explanation, clarification, safety, asynchronous work, failed operations, explicit resume, and non-resume acknowledgements
- wired the canonical rule into AGENTS.md, Claude, Gemini, Copilot, Cursor, and the coding-agent guidance

## Safety and scope

- instruction and documentation changes only
- no workflows, dependencies, credentials, production systems, or tool permissions changed
- does not attempt artificial self-approval
- existing asynchronous work may be reported but no new work is launched while paused

## Validation

- all tool adapters reference the same canonical guidance
- examples cover every question category in the issue
- explicit resume phrases and fail-fast behaviour are consistent across adapters
- repository CI will run the existing token-hygiene and helper-script checks

Closes #50