### PR TITLE
Add practical lower-model routing guidance

### DIFF
--- a/.cursor/rules/token-efficiency.mdc
+++ b/.cursor/rules/token-efficiency.mdc
@@ -27,6 +27,11 @@ Canonical guidance lives in:
 - Verify with the smallest useful command.
 - Keep final responses short.
 - Preserve accuracy over compression.
+- Use the lowest approved model tier capable of the task when routing is available.
+- Prefer economy/fast routing for bounded formatting, extraction, rewriting, and simple summarisation.
+- Escalate for security, production, architecture, ambiguity, broad multi-file work, sensitive data, or a materially failed first attempt.
+- If the current Cursor surface cannot change models, state the recommended tier rather than claiming a switch.
+- Never silently change provider, data boundary, tenancy, region, retention policy, or approved model family.
 - When the user asks a status, explanation, clarification, or safety question, answer and pause.
 - Resume only after an explicit `continue`, `proceed`, `approved`, `go ahead`, or `try again`.
 - Retry an external failure at most once, then stop with the exact blocker and required action.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,5 +19,10 @@ Canonical guidance lives in:
 - Avoid repeating generated code that already exists in the repository.
 - Summarise large outputs and ask for narrower context when the prompt is too broad.
 - Preserve correctness over brevity.
+- Use the lowest approved model tier capable of the task when routing is available.
+- Prefer economy/fast routing for bounded formatting, extraction, rewriting, and simple summarisation.
+- Escalate for security, production, architecture, ambiguity, broad multi-file work, sensitive data, or a materially failed first attempt.
+- If the current Copilot surface cannot change models, state the recommended tier rather than claiming a switch.
+- Never silently change provider, data boundary, tenancy, region, retention policy, or approved model family.
 - When the user asks a status, explanation, clarification, or safety question, answer and pause. Resume only after an explicit continuation phrase.
 - Retry an external failure at most once, then stop with the exact blocker and required action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ Canonical guidance lives in:
 - Make focused edits and avoid unrelated refactors.
 - Verify with the smallest useful command.
 - Preserve accuracy over compression.
+- Use the lowest approved model tier capable of the task when the host supports routing.
+- Prefer economy/fast models for bounded formatting, extraction, rewriting, and simple summarisation.
+- Escalate for security, production, architecture, ambiguity, broad multi-file work, sensitive data, or a materially failed first attempt.
+- If the host cannot switch models, state the recommended tier; never pretend a switch occurred.
+- Never silently switch provider, tenancy, region, retention policy, approved model family, or data boundary.
 
 ## Questions Pause Execution
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@ This file is a Claude-specific adapter. The canonical rules live in:
 - Summarise tool output and logs before continuing.
 - Prefer focused edits, targeted verification, and short final answers.
 - Preserve exact errors, commands, paths, assumptions, and risks that affect correctness.
+- Use the lowest approved model tier capable of the task when model routing is available.
+- Use economy/fast routing only for bounded, low-risk work such as formatting, extraction, rewriting, or simple summarisation.
+- Escalate for security, production, architecture, ambiguity, broad multi-file work, sensitive data, or a materially failed first attempt.
+- If this session cannot change models, state the recommended tier rather than claiming a switch.
+- Never silently change provider, data boundary, tenancy, region, retention policy, or approved model family.
 - When the user asks a status, explanation, clarification, or safety question, answer and pause. Resume only after an explicit continuation phrase.
 - Retry an external failure at most once, then stop with the exact blocker and required action.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -19,6 +19,11 @@ This file is a Gemini-specific adapter. The canonical rules live in:
 - Summarise long logs or files before reasoning over them.
 - Use structured summaries instead of long prose.
 - Do not reload or repeat unchanged context.
+- Use the lowest approved model tier capable of the task when routing is available.
+- Prefer economy/fast routing for bounded formatting, extraction, rewriting, and simple summarisation.
+- Escalate for security, production, architecture, ambiguity, broad multi-file work, sensitive data, or a materially failed first attempt.
+- If this session cannot change models, state the recommended tier rather than claiming a switch.
+- Never silently change provider, data boundary, tenancy, region, retention policy, or approved model family.
 - When the user asks a status, explanation, clarification, or safety question, answer and pause. Resume only after an explicit continuation phrase.
 - Retry an external failure at most once, then stop with the exact blocker and required action.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Ready-to-copy instruction files and supporting material:
 │   ├── ci-failure-triage.md
 │   ├── document-context-extraction.md
 │   ├── handoff-template.md
+│   ├── model-routing-decision.md
 │   ├── resource-discovery-measurement.csv
 │   └── token-savings-measurement.md
 └── checklists/
@@ -94,7 +95,8 @@ AI agents should:
 - Summarise large logs instead of repeating them.
 - Avoid restating unchanged context.
 - Keep persistent instruction and memory files short.
-- Use cheaper or faster models for simple tasks where appropriate.
+- Use the lowest approved model tier capable of the task.
+- Escalate early when security, production, architecture, ambiguity, sensitive data, or repeated failure appears.
 - Preserve technical accuracy over extreme compression.
 
 For tool-specific context risks, see the [per-tool token waste notes](guidelines/per-tool-notes.md).
@@ -102,6 +104,8 @@ For tool-specific context risks, see the [per-tool token waste notes](guidelines
 For common mistakes and fixes, see the [token waste anti-patterns catalogue](guidelines/anti-patterns.md).
 
 For PDFs, Office files, spreadsheets, screenshots, and scans, see the [document-to-Markdown context reduction guide](guidelines/document-to-markdown.md).
+
+For lower-model selection and escalation rules, see the [practical model-routing guide](guidelines/model-routing.md) and the [routing decision template](templates/model-routing-decision.md).
 
 ## Why This Matters
 
@@ -113,6 +117,29 @@ Token waste normally comes from four places:
 4. Poor model routing: using high-cost reasoning models for simple formatting, summarisation, or extraction.
 
 Short replies help, but context hygiene usually saves more.
+
+## Practical model routing
+
+Use capability tiers instead of hard-coding model names:
+
+| Tier | Example use |
+| --- | --- |
+| Economy / fast | Formatting, extraction, rewriting, selected-text summarisation, deterministic transformations |
+| Balanced | Scoped bug fixes, focused code review, ordinary engineering tasks with clear acceptance criteria |
+| Advanced reasoning | Security, production, architecture, incidents, ambiguous requirements, broad cross-system work |
+
+Recommended routing flow:
+
+```text
+confirm approved data boundary -> classify risk -> choose lowest capable tier -> verify -> escalate when triggered
+```
+
+Do not silently switch provider, tenancy, region, retention policy, approved model family, or data boundary merely to reduce cost. If the agent host cannot change models automatically, it should state the recommended tier rather than pretending a switch happened.
+
+Start with:
+
+- [Practical model-routing guide](guidelines/model-routing.md)
+- [Model-routing decision template](templates/model-routing-decision.md)
 
 ## Document-to-Markdown workflow
 

--- a/guidelines/model-routing.md
+++ b/guidelines/model-routing.md
@@ -1,38 +1,151 @@
 # Model Routing
 
-Do not use the strongest model for every task. Match the model to the job.
+Do not use the strongest model for every task. Use the **lowest approved model tier that can complete the task correctly**, then verify the result in proportion to the risk.
 
-## Use Cheaper/Faster Models For
+Model routing saves cost and latency only when it preserves correctness, security, data-handling requirements, and useful verification.
 
-- formatting
-- summarisation
-- simple Q&A
-- rewriting messages
-- extracting lists
-- basic code snippets
-- log summarisation
-- documentation cleanup
+## Vendor-Neutral Model Tiers
 
-## Use Stronger Models For
+Use capability tiers rather than hard-coding model names. Providers change model names and availability frequently.
 
-- architecture decisions
-- security review
-- complex debugging
-- multi-file refactors
-- infrastructure design
-- ambiguous requirements
-- production incident analysis
+| Tier | Intended use | Typical characteristics |
+| --- | --- | --- |
+| Economy / fast | Simple, bounded, low-risk work | Low latency, low cost, limited deep reasoning |
+| Balanced | Normal engineering work with moderate reasoning | Better code understanding and multi-step execution |
+| Advanced reasoning | Complex, ambiguous, high-risk, or cross-system work | Stronger reasoning, planning, and error analysis |
 
-## Routing Pattern
+Map these tiers to models that are approved by your organisation and available in your tool.
+
+## Good Economy / Fast Tasks
+
+Use an economy or fast model when the task is bounded, reversible, and easy to verify, such as:
+
+- formatting Markdown, YAML, JSON, or messages;
+- rewriting or shortening supplied text;
+- extracting lists, fields, headings, or action items;
+- classifying already-provided content;
+- summarising a known document or selected log section;
+- generating simple documentation from explicit facts;
+- producing a small code snippet from complete requirements;
+- mechanical search-and-replace changes;
+- adding straightforward tests for already-understood behaviour;
+- converting structured information into a requested template.
+
+A task is not simple merely because the requested answer is short. A one-line IAM, authentication, database, or production change can still be high risk.
+
+## Good Balanced Tasks
+
+Use a balanced model for ordinary engineering work that needs context and judgement but remains scoped, such as:
+
+- a well-defined bug fix in one component;
+- a small feature with clear acceptance criteria;
+- focused code review;
+- test failure diagnosis with a clear error and relevant files;
+- a limited refactor with known compatibility requirements;
+- Terraform or workflow explanation that does not change production controls;
+- documentation that requires reconciling several repository files.
+
+## Advanced Reasoning Tasks
+
+Start with or escalate to an advanced reasoning model for:
+
+- architecture and platform design;
+- security review, threat modelling, or privilege analysis;
+- production incident analysis;
+- infrastructure, IAM, DNS, networking, database, or deployment changes;
+- ambiguous or conflicting requirements;
+- broad multi-file or multi-service changes;
+- unfamiliar code with unclear ownership or side effects;
+- data-loss, privacy, legal, financial, or safety-sensitive decisions;
+- root-cause analysis after a simpler attempt fails;
+- tasks requiring comparison of several plausible designs.
+
+## Routing Decision
+
+Use this sequence before starting substantial work:
 
 ```text
-Classify task -> choose model -> limit context -> run -> verify
+1. Confirm approved provider, model family, and data boundary.
+2. Classify task risk and reversibility.
+3. Estimate reasoning and context complexity.
+4. Choose the lowest capable approved tier.
+5. Run the smallest useful verification.
+6. Escalate when a trigger is reached; do not loop repeatedly.
 ```
+
+## Mandatory Escalation Triggers
+
+Escalate from economy/fast to balanced or advanced reasoning when any of these occur:
+
+- the request touches security, authentication, authorisation, IAM, secrets, or cryptography;
+- production systems, customer data, infrastructure, deployments, migrations, or destructive actions are involved;
+- requirements are incomplete, contradictory, or materially ambiguous;
+- the change crosses several files, services, repositories, or trust boundaries;
+- the model cannot explain the likely blast radius or rollback path;
+- verification fails or the first result is materially incorrect;
+- the task requires choosing between architectural or operational trade-offs;
+- sensitive data requires a different approved model, region, tenancy, or provider boundary;
+- the model starts guessing missing facts instead of requesting the required context.
+
+Retry a failed economy-tier attempt at most once when the failure is clearly transient or easily corrected. Otherwise escalate the tier or stop and report the blocker.
+
+## Automatic Routing vs Recommendation
+
+Some agent hosts can select a model programmatically; others cannot.
+
+- **When automatic routing is supported and authorised:** select the lowest approved tier that meets this policy.
+- **When automatic routing is unavailable:** state the recommended tier in the plan or handoff. Do not pretend that a model switch occurred.
+- **When the user explicitly selected a model:** do not silently override that choice. Recommend a different tier only when it materially affects cost, capability, or safety.
+- **Never silently switch provider, tenancy, region, retention policy, or data boundary.** Model cost is secondary to approved data handling.
+
+Example recommendation:
+
+```text
+Recommended tier: Economy / fast
+Reason: Documentation formatting only; no code or security decisions.
+Verification: Markdown lint and link check.
+Escalate if: Source documents conflict or technical claims require validation.
+```
+
+## Verification by Tier
+
+Lower-cost routing must not remove validation.
+
+| Tier | Minimum verification examples |
+| --- | --- |
+| Economy / fast | Format check, schema parse, exact-field comparison, targeted lint |
+| Balanced | Relevant unit test, focused diff review, targeted build or validation command |
+| Advanced reasoning | Tests plus security/operational review, rollback analysis, stakeholder or human approval where required |
+
+A stronger model is not a substitute for tests or human approval. A lower model is not acceptable when its result cannot be checked cheaply and reliably.
+
+## Practical Examples
+
+| Task | Starting tier | Escalation condition |
+| --- | --- | --- |
+| Reformat a README table | Economy / fast | Technical content is inconsistent |
+| Extract action items from supplied notes | Economy / fast | Notes contain conflicting ownership or deadlines |
+| Summarise selected CI error lines | Economy / fast | Root cause is not evident from the selected evidence |
+| Fix a scoped unit-test failure | Balanced | Failure spans components or behaviour is unclear |
+| Review a GitHub Actions OIDC trust policy | Advanced reasoning | Always high risk; requires least-privilege review |
+| Design an AWS multi-region recovery pattern | Advanced reasoning | Always architectural and operationally significant |
+
+## Anti-Patterns
+
+Do not:
+
+- route solely by prompt length;
+- use an economy model for a high-risk one-line change;
+- keep retrying a weak model to avoid escalation cost;
+- send confidential content to a cheaper but unapproved provider;
+- use an advanced model for deterministic formatting that a simple tool can perform;
+- claim savings without recording the model, task, context, result, and verification;
+- assume model names map permanently to the same capability tier.
+
+## Reusable Routing Record
+
+Use [`templates/model-routing-decision.md`](../templates/model-routing-decision.md) when routing decisions need to be visible or measured.
 
 ## Practical Rule
 
-If a task does not require deep reasoning, do not pay for deep reasoning.
-
-## Safety Note
-
-Do not route sensitive data to models or providers that are not approved for that data classification.
+> If a task does not require deep reasoning, do not pay for deep reasoning. If risk or ambiguity rises, escalate early rather than paying for repeated weak attempts.

--- a/templates/model-routing-decision.md
+++ b/templates/model-routing-decision.md
@@ -1,0 +1,65 @@
+# Model Routing Decision
+
+Use this template when model selection affects cost, latency, capability, data handling, or safety.
+
+## Task
+
+- Request:
+- Expected output:
+- Scope:
+- Reversibility: Easy / Moderate / Difficult
+
+## Data Boundary
+
+- Data classification: Public / Internal / Confidential / Restricted
+- Approved provider or tenancy:
+- Approved model family:
+- Region or residency requirement:
+- Retention or training restriction:
+
+## Risk Classification
+
+- Risk: Low / Medium / High / Critical
+- Security or access impact:
+- Production impact:
+- Customer or personal-data impact:
+- Destructive or irreversible action:
+
+## Recommended Tier
+
+- Tier: Economy / fast | Balanced | Advanced reasoning
+- Reason:
+- Host can switch automatically: Yes / No
+- User selected a model explicitly: Yes / No
+
+## Context Plan
+
+- Minimum files or evidence required:
+- Context that should be excluded:
+- Logs or documents to summarise first:
+
+## Verification
+
+- Check or command:
+- Expected result:
+- Human approval required: Yes / No
+
+## Escalation Triggers
+
+Escalate or stop if:
+
+- requirements are ambiguous or conflicting;
+- the change crosses additional files, services, or trust boundaries;
+- security, production, data-loss, or compliance risk appears;
+- verification fails;
+- the first result is materially incorrect;
+- the model begins guessing missing facts.
+
+## Outcome
+
+- Tier actually used:
+- Result:
+- Verification result:
+- Escalated: Yes / No
+- Escalation reason:
+- Follow-up:


### PR DESCRIPTION
## What changed

- expanded the model-routing guide into a vendor-neutral economy/fast, balanced, and advanced-reasoning decision framework
- defined suitable lower-model tasks and mandatory escalation triggers
- added automatic-routing versus recommendation behaviour for hosts that cannot switch models
- added data-boundary, provider, tenancy, region, retention, and approved-model safeguards
- added verification expectations by model tier
- added a reusable model-routing decision template
- added concise routing rules to AGENTS.md, Claude, Gemini, Copilot, and Cursor adapters
- made model routing easier to discover from the README

## Safety and scope

- documentation and instruction files only
- no API calls, automatic model switching, provider configuration, credentials, workflows, or production systems changed
- guidance never permits silently changing provider or data boundary
- lower-cost routing is limited to bounded, low-risk, verifiable work
- security, production, architecture, sensitive data, ambiguity, and repeated failure require escalation

## Validation

- all adapter files point to the canonical model-routing guide
- model names are intentionally not hard-coded
- README paths match the repository structure
- instructions preserve verification and human approval requirements

Closes #54