### PR TITLE
Clarify long-lived assistant context hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ For PDFs, Office files, spreadsheets, screenshots, and scans, see the [document-
 
 For lower-model selection and escalation rules, see the [practical model-routing guide](guidelines/model-routing.md) and the [routing decision template](templates/model-routing-decision.md).
 
+For long-running chats and assistants, see the [long-lived assistant guidance](guidelines/context-hygiene.md#long-lived-assistants).
+
 ## Why This Matters
 
 Token waste normally comes from four places:
@@ -117,6 +119,20 @@ Token waste normally comes from four places:
 4. Poor model routing: using high-cost reasoning models for simple formatting, summarisation, or extraction.
 
 Short replies help, but context hygiene usually saves more.
+
+## Long-lived assistant context
+
+Long-running assistants should keep three concerns separate:
+
+```text
+active working context != durable memory != searchable full history
+```
+
+The active context should contain only the recent conversation and evidence needed for the current task. Durable memory should contain stable facts, preferences, decisions, procedures, and corrections. Full history should remain searchable for exact lookup rather than being loaded into every request.
+
+When the runtime supports context-window telemetry, monitor usage deterministically and compact before the provider limit. A safe compaction keeps recent turns, creates a structured continuation summary, verifies that the summary was saved, and retains the full history separately.
+
+This is a small operating guideline, not a memory-runtime implementation. Semantic memory graphs, automated conflict and staleness management, background consolidation, and platform-specific integrations remain future work.
 
 ## Practical model routing
 
@@ -223,7 +239,7 @@ Use your AI tool's token dashboard where available, or run the same workflow bef
 
 ### Is this only for coding agents?
 
-No. It works for AI chat, code review, incident triage, CI debugging, infrastructure-as-code, document review, documentation cleanup, and long-running engineering tasks.
+No. It works for AI chat, code review, incident triage, CI debugging, infrastructure-as-code, document review, documentation cleanup, and long-running engineering tasks. Runtime-specific memory and session-management implementations remain outside the current scope.
 
 ## What This Is Not
 
@@ -240,6 +256,7 @@ Use this playbook when working with:
 - CI/CD logs
 - infrastructure-as-code projects
 - long debugging sessions
+- long-lived assistants that need basic context and memory boundaries
 - repeated review or refactor workflows
 
 ## Contributing

--- a/guidelines/context-hygiene.md
+++ b/guidelines/context-hygiene.md
@@ -32,6 +32,35 @@ Bad context includes:
 - Replace long logs with summaries.
 - Keep project memory under active maintenance.
 
+## Long-Lived Assistants
+
+Long-lived conversational assistants should treat these as separate stores:
+
+1. **Active working context** — the recent conversation and evidence needed for the current task.
+2. **Durable memory** — stable facts, user preferences, decisions, procedures, and corrections that remain useful across sessions.
+3. **Searchable history** — the full transcript or archive retained for exact lookup, but not loaded into every request.
+
+Do not use a memory file as a complete conversation transcript. Keep durable memory concise, structured, current, and limited to information that is likely to matter again.
+
+When the runtime exposes context-window usage, prefer deterministic monitoring over asking the model to guess whether the conversation is too large. Compact before the provider limit is reached. The exact threshold is runtime-specific and should leave enough headroom for the summary, the next user turn, tool definitions, and model output.
+
+A safe compaction should:
+
+- preserve a recent verbatim tail of the conversation;
+- summarise the older portion into the task context, completed work, current state, next actions, important decisions, and user preferences;
+- keep exact errors, identifiers, commands, dates, and unresolved risks when they affect correctness;
+- retain the full history separately for later search;
+- verify that the summary was saved before discarding or rotating the old active context;
+- stop and report the problem if consolidation fails instead of silently losing context.
+
+A simple runtime pattern is:
+
+```text
+monitor context usage -> compact before the limit -> verify the summary -> continue or rotate the session
+```
+
+This playbook documents the operating principle only. Semantic memory graphs, automatic conflict and staleness management, background consolidation agents, and platform-specific integrations such as OpenClaw remain future work.
+
 ## Before Sending A Prompt
 
 Ask:


### PR DESCRIPTION
## What changed

- added a concise long-lived-assistant section to the context-hygiene guide
- separated active working context, durable memory, and searchable full history
- recommended deterministic context-window monitoring and compaction before provider limits
- documented safe compaction requirements: recent verbatim turns, structured continuation summary, preserved exact evidence, separate full history, save verification, and fail-safe behaviour
- clarified that memory files should contain durable facts rather than complete transcripts
- linked the guidance from the README and clarified current scope
- explicitly left semantic memory graphs, automated consolidation, and platform-specific runtime integrations as future work

## Safety and scope

- documentation only
- no runtime, model, provider, workflow, credential, memory store, OpenClaw installation, or production system changed
- no fixed compaction threshold is prescribed because provider and runtime headroom differ
- the repository does not claim to implement a memory runtime

## Validation

- links and heading anchors were reviewed
- README scope is consistent with the context-hygiene guide
- the change preserves the coding-agent focus while documenting the reusable long-lived-assistant principle

Closes #56