### PR TITLE
Add measured Terraform and multi-file refactor case studies

### DIFF
--- a/examples/case-study-multifile-refactor.md
+++ b/examples/case-study-multifile-refactor.md
@@ -1,0 +1,182 @@
+# Case Study: Multi-File Refactor
+
+This measured example shows how search results, interfaces, and one representative implementation can replace a full multi-file source dump when a repeated refactor is structurally uniform.
+
+## Scenario
+
+Ten TypeScript handler modules independently read `x-correlation-id`. A new `createRequestContext(request)` helper should replace that repeated logic while preserving logs, response bodies, repository contracts, and service behaviour.
+
+## Before
+
+The broad request included the complete contents of all ten handler modules. Each generated module contained twelve similar route handlers, so most of the context repeated imports, repository lookups, service calls, logging, and response construction.
+
+Prompt shape:
+
+```text
+Refactor this service so every handler uses the new request context helper. I pasted all handler files because the helper may affect any route.
+
+<91,217-character repository excerpt containing ten full modules>
+```
+
+## After
+
+The focused request included:
+
+- explicit acceptance criteria;
+- a repository map produced by search;
+- the helper interface;
+- one representative handler excerpt;
+- search evidence proving the same pattern exists in ten modules and nowhere else in production code;
+- the relevant unit and integration test locations;
+- a request to show the shared edit pattern rather than unchanged file bodies.
+
+Prompt shape:
+
+```text
+Plan and implement a scoped refactor to use createRequestContext(request). Preserve API responses and service behaviour.
+
+Acceptance criteria:
+- handlers must stop reading x-correlation-id directly;
+- correlationId must still appear in logs and response bodies;
+- no repository or service signatures may change;
+- add or update focused tests for the helper integration.
+
+Repository map from search:
+<five relevant path groups>
+
+Helper interface:
+<type and function signature>
+
+Representative current code:
+<one handler excerpt>
+
+Search evidence:
+rg -n 'x-correlation-id|randomUUID\(' src/handlers tests
+reports the same direct-read pattern in the ten handler modules and no other production files.
+```
+
+## Measurement
+
+The repository estimator reports:
+
+| Context | Bytes | Characters | Words | Lines | Estimated tokens |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Before | 91,217 | 91,217 | 9,222 | 2,136 | 22,804 |
+| After | 1,640 | 1,640 | 187 | 40 | 410 |
+| Delta | -89,577 | -89,577 | -9,035 | -2,096 | -22,394 |
+
+The result is specific to this generated fixture. It does not establish a fixed saving for real repositories or models.
+
+## Reproduce the fixture
+
+Run this from the repository root:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+from textwrap import dedent
+
+root = Path('/tmp/token-case-study-refactor')
+root.mkdir(parents=True, exist_ok=True)
+
+
+def build_module(index: int) -> str:
+    handlers = []
+    for route in range(1, 13):
+        handlers.append(dedent(f'''\
+export async function handleRoute{route:02d}(request: ApiRequest): Promise<ApiResponse> {{
+  const correlationId = request.headers["x-correlation-id"] ?? randomUUID();
+  logger.info({{ correlationId, route: "route-{route:02d}", module: "module-{index:02d}" }}, "request received");
+  const user = await userRepository.findById(request.userId);
+  if (!user) {{
+    return {{ statusCode: 404, body: JSON.stringify({{ error: "user_not_found", correlationId }}) }};
+  }}
+  const result = await service.execute({{
+    user,
+    payload: request.body,
+    correlationId,
+    feature: "feature-{index:02d}-{route:02d}",
+  }});
+  logger.info({{ correlationId, resultId: result.id }}, "request completed");
+  return {{ statusCode: 200, body: JSON.stringify({{ data: result, correlationId }}) }};
+}}
+'''))
+    return dedent(f'''\
+import {{ randomUUID }} from "node:crypto";
+import {{ logger }} from "../logging/logger";
+import {{ userRepository }} from "../repositories/user-repository";
+import {{ service }} from "../services/service";
+import type {{ ApiRequest, ApiResponse }} from "../types/api";
+
+// Full source for src/handlers/module-{index:02d}.ts
+''') + '\n'.join(handlers)
+
+files = [
+    f'--- src/handlers/module-{index:02d}.ts ---\n{build_module(index)}'
+    for index in range(1, 11)
+]
+
+before = dedent('''\
+Refactor this service so every handler uses the new request context helper. I pasted all handler files because the helper may affect any route. Please inspect the repository excerpt, decide what must change, update all relevant files, and explain the result.
+
+Requirement:
+Replace direct reads of x-correlation-id with createRequestContext(request), keep response payloads compatible, and do not change service behaviour.
+
+Full repository excerpt:
+''') + '\n\n'.join(files) + '\n'
+
+after = dedent('''\
+Plan and implement a scoped refactor to use createRequestContext(request). Preserve API responses and service behaviour.
+
+Acceptance criteria:
+- handlers must stop reading x-correlation-id directly;
+- correlationId must still appear in logs and response bodies;
+- no repository or service signatures may change;
+- add or update focused tests for the helper integration.
+
+Repository map from search:
+- src/context/request-context.ts: defines createRequestContext(request)
+- src/types/api.ts: defines ApiRequest and ApiResponse
+- src/handlers/module-01.ts through module-10.ts: same repeated handler pattern
+- tests/request-context.test.ts: helper unit tests
+- tests/handler-context.test.ts: representative handler integration test
+
+Helper interface:
+export type RequestContext = {
+  correlationId: string;
+};
+
+export function createRequestContext(request: ApiRequest): RequestContext;
+
+Representative current code from src/handlers/module-01.ts:
+const correlationId = request.headers["x-correlation-id"] ?? randomUUID();
+logger.info({ correlationId, route: "route-01", module: "module-01" }, "request received");
+const result = await service.execute({
+  user,
+  payload: request.body,
+  correlationId,
+  feature: "feature-01-01",
+});
+return { statusCode: 200, body: JSON.stringify({ data: result, correlationId }) };
+
+Search evidence:
+rg -n 'x-correlation-id|randomUUID\\(' src/handlers tests
+reports the same direct-read pattern in the ten handler modules and no other production files.
+
+Requested output:
+Show the shared edit pattern, list affected files, and give the smallest verification commands. Do not paste unchanged handler bodies.
+''')
+
+(root / 'before.txt').write_text(before, encoding='utf-8')
+(root / 'after.txt').write_text(after, encoding='utf-8')
+PY
+
+python3 scripts/estimate-context-size.py \
+  /tmp/token-case-study-refactor/before.txt \
+  /tmp/token-case-study-refactor/after.txt \
+  --markdown
+```
+
+## Correctness safeguard
+
+This technique is appropriate only after search confirms that the repeated pattern is genuinely uniform. Read additional files when modules have different side effects, error handling, ownership, tests, generated code, or compatibility requirements. The final change should still be verified with focused tests and a diff review across every affected file.

--- a/examples/case-study-terraform-debug.md
+++ b/examples/case-study-terraform-debug.md
@@ -1,0 +1,253 @@
+# Case Study: Terraform Debugging
+
+This measured example shows how to preserve the exact Terraform failure signal without sending an entire plan, debug trace, and unrelated module files to an AI agent.
+
+## Scenario
+
+A development environment was reduced from two private subnets to one. A module output still selected `aws_subnet.private[1]`, so `terraform plan` failed with `Invalid index`.
+
+## Before
+
+The original request included:
+
+- the full root module;
+- all network-module variables, resources, and outputs;
+- the complete development variables file;
+- 80 unrelated ECS task-definition plan entries;
+- 60 successful provider debug lines;
+- the error at the end of the output.
+
+Prompt shape:
+
+```text
+Diagnose this Terraform plan failure. I pasted the full root module, all network module files, and the complete plan/debug output because I am not sure what is relevant.
+
+<34,658-character context containing full files and debug output>
+```
+
+## After
+
+The focused request retained:
+
+- the exact error and source location;
+- the relevant `aws_subnet.private` resource;
+- the failing output;
+- the one-subnet development values;
+- the recent configuration change;
+- the compatibility constraint for environments with one or more subnets;
+- the requested diagnosis, minimal correction, and validation command.
+
+Prompt shape:
+
+```text
+Diagnose this Terraform failure. Give the root cause, the smallest safe code correction, and one validation command. Do not redesign the network.
+
+Exact error:
+Error: Invalid index
+  on modules/network/outputs.tf line 14:
+  value = aws_subnet.private[1].id
+  aws_subnet.private is tuple with 1 element
+
+Relevant resource and output:
+<selected blocks only>
+
+Recent change:
+Dev was reduced from two private subnets to one. Production still uses two.
+
+Constraint:
+Keep the module valid for environments with one or more private subnets.
+```
+
+## Measurement
+
+The repository estimator reports:
+
+| Context | Bytes | Characters | Words | Lines | Estimated tokens |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Before | 34,694 | 34,658 | 2,577 | 721 | 8,664 |
+| After | 955 | 955 | 112 | 31 | 239 |
+| Delta | -33,739 | -33,703 | -2,465 | -690 | -8,425 |
+
+The result is specific to this generated fixture. It is not a universal percentage claim.
+
+## Reproduce the fixture
+
+Run this from the repository root:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+from textwrap import dedent
+
+root = Path('/tmp/token-case-study-terraform')
+root.mkdir(parents=True, exist_ok=True)
+
+plan = [
+    'Terraform used the selected providers to generate the following execution plan.',
+    'Resource actions are indicated with the following symbols:',
+    '  + create',
+    '  ~ update in-place',
+    '',
+]
+for i in range(1, 81):
+    plan.extend([
+        f'  # module.service.aws_ecs_task_definition.revision_{i:02d} will be updated in-place',
+        f'  ~ resource "aws_ecs_task_definition" "revision_{i:02d}" {{',
+        f'        family                   = "example-service-{i:02d}"',
+        '      ~ container_definitions    = (sensitive value)',
+        '        requires_compatibilities = ["FARGATE"]',
+        '    }',
+        '',
+    ])
+for i in range(1, 61):
+    plan.append(
+        f'2026-07-30T08:{i % 60:02d}:12.000Z [DEBUG] provider.terraform-provider-aws: '
+        f'request_id=req-{i:03d} operation=DescribeSubnets status=200 retry=0'
+    )
+plan.extend([
+    '',
+    'Error: Invalid index',
+    '',
+    '  on modules/network/outputs.tf line 14, in output "private_subnet_id":',
+    '  14: value = aws_subnet.private[1].id',
+    '    ├────────────────',
+    '    │ aws_subnet.private is tuple with 1 element',
+    '',
+    'The given key does not identify an element in this collection value: the given index is greater than or equal to the length of the collection.',
+])
+
+before = dedent('''\
+Diagnose this Terraform plan failure. I pasted the full root module, all network module files, and the complete plan/debug output because I am not sure what is relevant.
+
+--- main.tf ---
+module "network" {
+  source = "./modules/network"
+
+  environment          = var.environment
+  availability_zones   = var.availability_zones
+  private_subnet_cidrs = var.private_subnet_cidrs
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  enable_nat_gateway   = var.enable_nat_gateway
+  tags                 = local.common_tags
+}
+
+module "service" {
+  source = "./modules/service"
+
+  cluster_arn       = aws_ecs_cluster.main.arn
+  private_subnet_id = module.network.private_subnet_id
+  security_group_id = aws_security_group.service.id
+  image             = var.image
+  desired_count     = var.desired_count
+  tags              = local.common_tags
+}
+
+--- modules/network/variables.tf ---
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones used by the VPC"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Private subnet CIDR blocks"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public subnet CIDR blocks"
+}
+
+variable "enable_nat_gateway" {
+  type        = bool
+  description = "Whether to create a NAT gateway"
+}
+
+--- modules/network/subnets.tf ---
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  availability_zone = var.availability_zones[count.index]
+  cidr_block        = var.private_subnet_cidrs[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-private-${count.index + 1}"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.main.id
+  availability_zone       = var.availability_zones[count.index]
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-public-${count.index + 1}"
+  })
+}
+
+--- modules/network/outputs.tf ---
+output "private_subnet_id" {
+  description = "Second private subnet used by the example service"
+  value       = aws_subnet.private[1].id
+}
+
+--- environments/dev.tfvars ---
+environment          = "dev"
+availability_zones   = ["eu-west-2a"]
+private_subnet_cidrs = ["10.20.1.0/24"]
+public_subnet_cidrs  = ["10.20.101.0/24"]
+enable_nat_gateway   = false
+
+--- terraform plan -no-color with TF_LOG=DEBUG ---
+''') + '\n'.join(plan) + '\n'
+
+after = dedent('''\
+Diagnose this Terraform failure. Give the root cause, the smallest safe code correction, and one validation command. Do not redesign the network.
+
+Exact error:
+Error: Invalid index
+  on modules/network/outputs.tf line 14:
+  value = aws_subnet.private[1].id
+  aws_subnet.private is tuple with 1 element
+
+Relevant resource:
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+  availability_zone = var.availability_zones[count.index]
+  cidr_block        = var.private_subnet_cidrs[count.index]
+}
+
+Relevant output:
+output "private_subnet_id" {
+  description = "Second private subnet used by the example service"
+  value       = aws_subnet.private[1].id
+}
+
+Relevant dev values:
+availability_zones   = ["eu-west-2a"]
+private_subnet_cidrs = ["10.20.1.0/24"]
+
+Recent change:
+Dev was reduced from two private subnets to one. Production still uses two.
+
+Constraint:
+Keep the module valid for environments with one or more private subnets.
+''')
+
+(root / 'before.txt').write_text(before, encoding='utf-8')
+(root / 'after.txt').write_text(after, encoding='utf-8')
+PY
+
+python3 scripts/estimate-context-size.py \
+  /tmp/token-case-study-terraform/before.txt \
+  /tmp/token-case-study-terraform/after.txt \
+  --markdown
+```
+
+## Correctness safeguard
+
+The focused context should be expanded when the failure depends on additional module contracts, state, provider versions, generated configuration, or environment-specific behaviour. Context reduction is successful only when the diagnosis and verification remain correct.


### PR DESCRIPTION
## What changed

- added a Terraform debugging case study that compares a full plan/debug dump with a focused failure context
- added a multi-file refactor case study that compares full repeated source files with search evidence, interfaces, and a representative implementation
- included deterministic fixture generators and exact estimator commands for both examples
- recorded bytes, characters, words, lines, approximate tokens, deltas, and correctness safeguards

## Measurement and caveats

- measurements use the repository's dependency-free `scripts/estimate-context-size.py`
- fixtures are synthetic, deterministic, and reproducible from the documented commands
- the case studies make no universal or fixed percentage saving claim
- both examples state when additional context must be read to preserve correctness

## Scope and safety

- documentation examples only
- no dependencies, workflows, permissions, credentials, provider configuration, or runtime behaviour changed

Closes #9