### PR TITLE
Strengthen context estimator regression coverage

### DIFF
--- a/.github/workflows/token-hygiene.yml
+++ b/.github/workflows/token-hygiene.yml
@@ -20,6 +20,3 @@ jobs:
 
       - name: Run token hygiene script
         run: bash scripts/check-token-hygiene.sh
-
-      - name: Run context size estimator tests
-        run: python3 -m unittest discover -s tests -p 'test_estimate_context_size.py' -v

--- a/.github/workflows/token-hygiene.yml
+++ b/.github/workflows/token-hygiene.yml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Run token hygiene script
         run: bash scripts/check-token-hygiene.sh
+
+      - name: Run context size estimator tests
+        run: python3 -m unittest discover -s tests -p 'test_estimate_context_size.py' -v

--- a/tests/test_estimate_context_size.py
+++ b/tests/test_estimate_context_size.py
@@ -21,22 +21,28 @@ class EstimateContextSizeTests(unittest.TestCase):
         self.assertEqual(estimator.estimate_tokens("a"), 1)
         self.assertEqual(estimator.estimate_tokens("abcdefgh"), 2)
 
-    def test_iter_files_is_sorted_and_excludes_git_metadata(self) -> None:
+    def test_iter_files_is_recursive_sorted_and_excludes_git_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
+            (root / "nested").mkdir()
             (root / "b.txt").write_text("b", encoding="utf-8")
-            (root / "a.txt").write_text("a", encoding="utf-8")
+            (root / "nested" / "a.txt").write_text("a", encoding="utf-8")
             (root / ".git").mkdir()
             (root / ".git" / "config").write_text("secret", encoding="utf-8")
 
-            files = [path.name for path in estimator.iter_files([str(root)])]
-            self.assertEqual(files, ["a.txt", "b.txt"])
+            files = list(estimator.iter_files([str(root)]))
+            self.assertEqual(files, [root / "b.txt", root / "nested" / "a.txt"])
 
-    def test_read_text_replaces_invalid_utf8(self) -> None:
+    def test_read_text_preserves_unicode_and_replaces_invalid_utf8(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "input.bin"
-            path.write_bytes(b"good\xffbad")
-            self.assertEqual(estimator.read_text(path), "good\ufffdbad")
+            root = Path(directory)
+            unicode_path = root / "unicode.txt"
+            invalid_path = root / "input.bin"
+            unicode_path.write_text("café ☕", encoding="utf-8")
+            invalid_path.write_bytes(b"good\xffbad")
+
+            self.assertEqual(estimator.read_text(unicode_path), "café ☕")
+            self.assertEqual(estimator.read_text(invalid_path), "good\ufffdbad")
 
     def test_markdown_cli_reports_unicode_totals(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## What changed

- strengthened the existing context-size estimator regression tests with recursive file discovery coverage
- explicitly verifies Unicode preservation as well as invalid UTF-8 replacement
- keeps the change focused on the existing dependency-free test suite

## Safety and scope

- tests only; no estimator behaviour changed
- no model APIs, network calls, credentials, dependencies, workflow permissions, production systems, or infrastructure are used
- the repository's existing credential-free Helper script tests continue to run the estimator suite

## Validation

- regression coverage includes empty/non-empty estimates, deterministic recursive discovery, `.git` exclusion, Unicode and invalid UTF-8 handling, missing paths, Markdown totals, and the approximation warning
- applicable GitHub Actions checks must pass before merge

Closes #44