### PR TITLE
Count instruction lines correctly without a final newline

### DIFF
--- a/scripts/check-token-hygiene.sh
+++ b/scripts/check-token-hygiene.sh
@@ -15,7 +15,7 @@ check_instruction_file() {
   fi
 
   local lines
-  lines=$(wc -l < "$file" | tr -d ' ')
+  lines=$(awk 'END { print NR }' "$file")
 
   if [ "$lines" -gt "$MAX_INSTRUCTION_LINES" ]; then
     echo "instruction-too-large: $file has $lines lines; limit is $MAX_INSTRUCTION_LINES"

--- a/tests/test_check_token_hygiene.sh
+++ b/tests/test_check_token_hygiene.sh
@@ -81,6 +81,13 @@ expect_failure \
   bash -c "cd '$repo' && MAX_INSTRUCTION_LINES=2 bash '$CHECK_SCRIPT'"
 
 repo=$(new_repo)
+printf 'one\ntwo\nthree' > "$repo/AGENTS.md"
+expect_failure \
+  "oversized instruction file without final newline" \
+  "instruction-too-large: AGENTS.md has 3 lines" \
+  bash -c "cd '$repo' && MAX_INSTRUCTION_LINES=2 bash '$CHECK_SCRIPT'"
+
+repo=$(new_repo)
 dd if=/dev/zero of="$repo/untracked.log" bs=1024 count=16 status=none
 expect_success \
   "untracked files are outside staged check" \


### PR DESCRIPTION
## Summary

- count logical instruction-file lines with `awk` instead of newline characters with `wc -l`
- catch oversized instruction files even when the final line has no trailing newline
- add a regression case for that boundary condition

## Safety

No thresholds, dependencies, workflow permissions, credentials, or external services are changed.

Closes #70