### PR TITLE
Report actual bytes and logical lines in context estimates

### DIFF
--- a/scripts/estimate-context-size.py
+++ b/scripts/estimate-context-size.py
@@ -54,10 +54,10 @@ def main() -> int:
 
     for path in iter_files(args.paths):
         text = read_text(path)
-        byte_count = len(text.encode("utf-8"))
+        byte_count = path.stat().st_size
         char_count = len(text)
         word_count = len(text.split())
-        line_count = text.count("\n") + (1 if text else 0)
+        line_count = len(text.splitlines())
         token_estimate = estimate_tokens(text)
         rows.append((str(path), byte_count, char_count, word_count, line_count, token_estimate))
         totals[0] += byte_count

--- a/tests/test_estimate_context_size.py
+++ b/tests/test_estimate_context_size.py
@@ -65,8 +65,25 @@ class EstimateContextSizeTests(unittest.TestCase):
                 text=True,
             )
 
-            self.assertIn("| **Total** | 15 | 14 | 3 | 4 | 4 |", result.stdout)
+            self.assertIn("| **Total** | 15 | 14 | 3 | 2 | 4 |", result.stdout)
             self.assertIn("est_tokens is approximate", result.stdout)
+
+    def test_cli_reports_original_byte_size_for_invalid_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "invalid.bin"
+            path.write_bytes(b"\xff\n")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), str(path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertIn(
+                "bytes=2 chars=2 words=1 lines=1 est_tokens=1",
+                result.stdout,
+            )
 
     def test_missing_path_is_warned_and_skipped(self) -> None:
         result = subprocess.run(


### PR DESCRIPTION
## Summary

- report actual file byte sizes in context measurements
- count logical lines correctly for newline-terminated text
- add regression tests for invalid UTF-8 byte size and Markdown totals

Closes #72