### PR TITLE
Fix overlapping context path double-counting

### DIFF
--- a/scripts/estimate-context-size.py
+++ b/scripts/estimate-context-size.py
@@ -15,13 +15,22 @@ from typing import Iterable
 
 
 def iter_files(paths: Iterable[str]) -> Iterable[Path]:
+    seen: set[Path] = set()
     for raw_path in paths:
         path = Path(raw_path)
         if path.is_dir():
             for child in sorted(path.rglob("*")):
                 if child.is_file() and ".git" not in child.parts:
+                    canonical = child.resolve()
+                    if canonical in seen:
+                        continue
+                    seen.add(canonical)
                     yield child
         elif path.is_file():
+            canonical = path.resolve()
+            if canonical in seen:
+                continue
+            seen.add(canonical)
             yield path
         else:
             print(f"warning: skipped missing path: {path}", file=sys.stderr)

--- a/tests/test_estimator_path_dedup.py
+++ b/tests/test_estimator_path_dedup.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "estimate-context-size.py"
+SPEC = importlib.util.spec_from_file_location("estimate_context_size_dedup", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+estimator = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = estimator
+SPEC.loader.exec_module(estimator)
+
+
+class ContextPathDedupTests(unittest.TestCase):
+    def test_directory_and_nested_file_are_counted_once(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first.md"
+            second = root / "second.md"
+            first.write_text("first\n", encoding="utf-8")
+            second.write_text("second\n", encoding="utf-8")
+
+            files = list(estimator.iter_files([str(root), str(first)]))
+
+            self.assertEqual(files, [first, second])
+
+    def test_first_seen_display_path_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            nested = root / "nested"
+            nested.mkdir()
+            target = nested / "context.md"
+            target.write_text("context\n", encoding="utf-8")
+
+            files = list(estimator.iter_files([str(target), str(root)]))
+
+            self.assertEqual(files, [target])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- de-duplicates canonical file paths when estimator inputs overlap
- preserves the first-seen display path and deterministic traversal order
- adds regression coverage for directory-plus-file and file-plus-directory inputs
- keeps the estimator dependency-free and does not change token approximation behavior

## Validation

Existing credential-free helper-script CI exercises the estimator tests on pull requests.

Closes #74