### PR TITLE
Add token hygiene workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Token Efficiency Playbook
 
+[![Token hygiene](https://github.com/ravinperera/ai-token-efficiency-playbook/actions/workflows/token-hygiene.yml/badge.svg)](https://github.com/ravinperera/ai-token-efficiency-playbook/actions/workflows/token-hygiene.yml)
+
 Drop-in instructions, prompts, examples, and lightweight checks to reduce wasted AI tokens across Codex, Claude Code, GitHub Copilot, Cursor, Gemini, and other AI coding agents.
 
 This project is not just about making AI replies shorter. The main thesis is:


### PR DESCRIPTION
## Summary

Add the missing Token hygiene GitHub Actions status badge to the README so the repository visibly dogfoods its own hygiene check.

## Why this helps

Issue #8 already has the credential-free workflow running on pull requests and pushes to `main`; this completes the remaining README visibility acceptance criterion without changing workflow behaviour or permissions.

## Scope

- Included: README status badge for `.github/workflows/token-hygiene.yml`.
- Intentionally excluded: workflow logic, permissions, dependencies, thresholds, and runtime behaviour.

## Validation

- Verified `.github/workflows/token-hygiene.yml` runs on pull requests and pushes to `main` with `contents: read`.
- Existing repository checks should validate the documentation-only change.

## Safety checklist

- [x] The pull request is focused and contains no unrelated changes.
- [x] No secrets, credentials, private URLs, customer data, sensitive logs, or confidential prompts are included.
- [x] Provider, tenancy, region, retention policy, approved model family, and data boundaries are unchanged.
- [x] No workflow permissions, dependencies, infrastructure, or production behaviour are changed.

Closes #8