### PR TITLE
Document progressive context retrieval patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Ready-to-copy instruction files and supporting material:
 │   ├── token-saving-principles.md
 │   ├── coding-agent-guidelines.md
 │   ├── context-hygiene.md
+│   ├── progressive-context-retrieval.md
 │   ├── cli-output-compression.md
 │   ├── document-to-markdown.md
 │   ├── model-routing.md
@@ -91,6 +92,7 @@ AI agents should:
 
 - Use context hygiene before optimizing response style.
 - Search before reading large files.
+- Use progressive retrieval: discover structure first, then load the smallest relevant symbol or range.
 - Read the smallest relevant file range.
 - Convert text-heavy documents to searchable Markdown before loading whole documents or screenshot collections.
 - Keep the original visual only when layout, charts, diagrams, or image content affect the answer.
@@ -102,6 +104,8 @@ AI agents should:
 - Preserve technical accuracy over extreme compression.
 
 For tool-specific context risks, see the [per-tool token waste notes](guidelines/per-tool-notes.md).
+
+For codebase discovery, structural views, persistent code indexes, context receipts, and canonical project context, see [progressive context retrieval](guidelines/progressive-context-retrieval.md).
 
 For common mistakes and fixes, see the [token waste anti-patterns catalogue](guidelines/anti-patterns.md).
 
@@ -255,7 +259,7 @@ Use this playbook when working with:
 
 - AI coding agents
 - terminal-based AI tools
-- large codebases
+- large codebases and codebases with reusable structural indexes
 - text-heavy documents and screenshot collections
 - CI/CD logs
 - infrastructure-as-code projects

--- a/guidelines/context-hygiene.md
+++ b/guidelines/context-hygiene.md
@@ -32,6 +32,18 @@ Bad context includes:
 - Replace long logs with summaries.
 - Keep project memory under active maintenance.
 
+## Progressive Repository Retrieval
+
+For codebase work, use progressive disclosure instead of treating a full file as the default retrieval unit:
+
+```text
+metadata / search -> structure / outline -> relevant symbol or range -> full file only when justified
+```
+
+Persistent symbol indexes or code graphs can help discover architecture without repeatedly rereading source, but cached structure must be tied to the correct repository/revision and verified against authoritative files when freshness or correctness matters.
+
+See [progressive context retrieval](progressive-context-retrieval.md) for structural views, persistent code memory, context receipts, canonical project context, and safe escalation rules.
+
 ## Long-Lived Assistants
 
 Long-lived conversational assistants should treat these as separate stores:
@@ -59,7 +71,7 @@ A simple runtime pattern is:
 monitor context usage -> compact before the limit -> verify the summary -> continue or rotate the session
 ```
 
-This playbook documents the operating principle only. Semantic memory graphs, automatic conflict and staleness management, background consolidation agents, and platform-specific integrations such as OpenClaw remain future work.
+This playbook documents operating principles rather than implementing a memory runtime. Automated conflict resolution, background consolidation agents, and platform-specific memory integrations remain implementation-specific work.
 
 ## Multi-Agent Context
 

--- a/guidelines/progressive-context-retrieval.md
+++ b/guidelines/progressive-context-retrieval.md
@@ -1,0 +1,176 @@
+# Progressive Context Retrieval
+
+Large codebases do not need to be loaded into an AI agent all at once. A better default is to reveal context in layers and stop as soon as the task is answerable.
+
+Use this progression:
+
+```text
+metadata / search -> structure / outline -> relevant symbol or range -> full file only when justified
+```
+
+This pattern reduces repeated context, keeps evidence focused, and makes it easier to measure what each retrieval step actually costs.
+
+## 1. Start With Discovery, Not File Dumps
+
+Before reading a large file, first identify where the answer is likely to live.
+
+Prefer:
+
+- repository metadata and changed-file lists;
+- filename and symbol search;
+- dependency or call-graph queries;
+- directory listings;
+- headings, signatures, or structural outlines;
+- exact error locations and stack frames.
+
+Only load source bodies after discovery has narrowed the candidate set.
+
+## 2. Use Structural Views Before Full Content
+
+For large source files, a structural view can often answer the first question: what is here and where is the relevant part?
+
+A structural view might contain:
+
+- function, class, method, route, resource, or module names;
+- signatures and type information;
+- line ranges;
+- imports and dependencies;
+- call relationships;
+- configuration keys;
+- headings for documentation.
+
+After locating the likely symbol or section, retrieve only that implementation plus the minimum surrounding context required to reason safely.
+
+Do not assume an outline is sufficient for behavioural changes. Read the implementation, tests, and callers when correctness depends on them.
+
+## 3. Reuse Structural Memory Carefully
+
+A persistent repository index, code graph, symbol database, or retrieval cache can avoid rediscovering the same architecture on every session.
+
+Use persistent structural memory for questions such as:
+
+- where is this function defined?
+- what calls this component?
+- which routes reach this handler?
+- which files depend on this module?
+- what changed around this symbol?
+
+Treat the index as a discovery layer, not unquestioned ground truth.
+
+Before relying on it for a material decision:
+
+- confirm which repository and revision it represents;
+- refresh or invalidate it after relevant changes;
+- fall back to source when the index is incomplete or stale;
+- verify high-impact conclusions against authoritative files;
+- keep project boundaries explicit so results from one codebase do not leak into another.
+
+## 4. Make Context Consumption Observable
+
+Where the runtime exposes enough telemetry, record a small context receipt for meaningful reads.
+
+Useful fields include:
+
+```text
+source/ref
+view type
+bytes returned
+estimated or provider-reported input tokens
+tool calls
+bytes or sections avoided, if measured
+freshness / index revision
+reason for escalation to a larger view
+```
+
+Receipts make it possible to distinguish real context reduction from workflows that simply hide cost across more tool calls.
+
+Do not infer a fixed token-saving percentage from bytes alone. Tokenization, tool envelopes, duplicated prompts, retries, and model behaviour all affect total cost.
+
+## 5. Escalate Context Deliberately
+
+Move to a larger view only when the smaller view cannot answer the task safely.
+
+Examples:
+
+- A symbol search finds the handler, but a bug fix requires its implementation and tests.
+- A call graph identifies callers, but an API change requires reading the compatibility layer.
+- A structural outline shows configuration keys, but a security review requires exact default values and validation logic.
+
+A useful escalation note is short:
+
+```text
+Need full implementation because the decision depends on error handling not visible in the outline.
+```
+
+This creates an audit trail without forcing verbose reasoning into every prompt.
+
+## 6. Keep One Canonical Project Context
+
+Repeated platform-specific instruction files can become both a token cost and a governance drift risk.
+
+Prefer:
+
+```text
+canonical project context / policy
+        -> thin Codex adapter
+        -> thin Claude adapter
+        -> thin Copilot adapter
+        -> thin Cursor adapter
+        -> thin Gemini adapter
+```
+
+The canonical source should hold shared architecture, safety boundaries, validation commands, and durable project conventions. Provider-specific files should contain only tool-specific behaviour, routing details, or constraints that cannot be expressed once.
+
+This repository follows that principle: `guidelines/` contains the canonical guidance while files such as `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` remain adapters.
+
+## 7. Separate Retrieval Policy From Prompt Advice
+
+Prompt instructions such as "read only what you need" are useful, but a retrieval layer can enforce stronger limits where the environment supports it.
+
+Possible controls include:
+
+- refuse secrets, binaries, generated output, or oversized lockfiles by default;
+- return an outline for large files before allowing a full read;
+- cap ranges or response sizes;
+- require a reason before escalating to a larger view;
+- log what was requested versus what was returned.
+
+Do not block evidence required for correctness. Security-sensitive and production work may legitimately require broader context than routine editing.
+
+## Practical Workflow
+
+```text
+1. identify the task and authoritative repository/ref
+2. search for candidate files/symbols
+3. query structure or persistent index if available
+4. read the smallest relevant implementation range
+5. expand to callers/tests/config only when the decision requires it
+6. verify against source when using cached or indexed knowledge
+7. record total workflow cost when benchmarking
+```
+
+## When Full-File Reads Are Reasonable
+
+A full file can still be the cheapest safe choice when it is:
+
+- small;
+- tightly scoped to the task;
+- a policy or configuration file whose global interactions matter;
+- a test file where fixture/setup context is required;
+- easier to load once than repeatedly retrieve many overlapping ranges.
+
+The goal is not to minimize every individual read. The goal is to minimize total irrelevant context while preserving correctness.
+
+## Related Implementations
+
+These public projects illustrate useful implementation patterns without defining this playbook's requirements:
+
+- [Graft](https://github.com/flyingrobots/graft) demonstrates governed structural reads, refusals, and context receipts.
+- [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) demonstrates a persistent structural code index and graph-style queries.
+- [OpenMontage](https://github.com/open-montage/OpenMontage) demonstrates a canonical shared project context with tool- and stage-specific knowledge loaded as needed.
+
+Treat their performance claims as project-specific until reproduced on your own workload. The playbook deliberately keeps the pattern vendor-neutral.
+
+## Measurement
+
+When evaluating this approach, compare the complete workflow rather than one tool response. Use the [structural-memory retrieval benchmark](../benchmarks/structural-memory-retrieval.md) when available and capture task success alongside tokens, bytes, tool calls, latency, and freshness failures.

--- a/guidelines/progressive-context-retrieval.md
+++ b/guidelines/progressive-context-retrieval.md
@@ -173,4 +173,4 @@ Treat their performance claims as project-specific until reproduced on your own 
 
 ## Measurement
 
-When evaluating this approach, compare the complete workflow rather than one tool response. Use the [structural-memory retrieval benchmark](../benchmarks/structural-memory-retrieval.md) when available and capture task success alongside tokens, bytes, tool calls, latency, and freshness failures.
+When evaluating this approach, compare the complete workflow rather than one tool response. Capture task success alongside tokens, bytes, tool calls, latency, freshness failures, and indexing overhead so local efficiency does not hide total workflow cost.


### PR DESCRIPTION
## Summary

- add a vendor-neutral progressive retrieval guide for codebase context
- cover structural outlines, persistent code indexes, context receipts, and safe escalation
- reinforce one canonical project context with thin provider-specific adapters
- link the guidance from the README and context-hygiene guide

No dependencies, workflow permissions, credentials, runtime behaviour, or fixed savings claims were added.

Closes #79