### PR TITLE
Add safe one-command instruction installer

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Test token hygiene checker
         run: bash tests/test_check_token_hygiene.sh
+
+      - name: Test instruction installer
+        run: sh tests/test_install.sh

--- a/README.md
+++ b/README.md
@@ -12,9 +12,19 @@ Most token waste comes from oversized context, repeated memory, noisy logs, and 
 
 ## 30-Second Install
 
-Pick your tool, copy the matching file into your repository, and commit it.
+Run the installer from the root of the repository that should receive the instruction file. Replace `codex` with `claude`, `gemini`, `copilot`, or `cursor` as needed.
 
-| Tool | Copy this file |
+```bash
+curl -fsSL https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/scripts/install.sh | sh -s -- codex
+```
+
+The installer maps each tool to its canonical file and **refuses to overwrite an existing file**. Review an existing instruction file first; use `--force` only when replacement is intentional.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main/scripts/install.sh | sh -s -- --force codex
+```
+
+| Tool | Installed file |
 | --- | --- |
 | Codex / general coding agents | `AGENTS.md` |
 | Claude Code | `CLAUDE.md` |
@@ -22,11 +32,7 @@ Pick your tool, copy the matching file into your repository, and commit it.
 | GitHub Copilot | `.github/copilot-instructions.md` |
 | Cursor | `.cursor/rules/token-efficiency.mdc` |
 
-```bash
-cp AGENTS.md /path/to/your-repo/AGENTS.md
-```
-
-For best results, also copy the canonical guidance in `guidelines/` and the checklist in `checklists/token-efficiency-checklist.md`.
+For best results, also use the canonical guidance in `guidelines/` and the checklist in `checklists/token-efficiency-checklist.md`.
 
 ## What This Provides
 
@@ -67,10 +73,12 @@ Ready-to-copy instruction files and supporting material:
 │   └── dynamic-resource-discovery.md
 ├── scripts/
 │   ├── check-token-hygiene.sh
-│   └── estimate-context-size.py
+│   ├── estimate-context-size.py
+│   └── install.sh
 ├── tests/
 │   ├── test_check_token_hygiene.sh
-│   └── test_estimate_context_size.py
+│   ├── test_estimate_context_size.py
+│   └── test_install.sh
 ├── templates/
 │   ├── ci-failure-triage.md
 │   ├── document-context-extraction.md
@@ -219,14 +227,15 @@ To produce rough before/after context-size numbers for a case study, use the dep
 python3 scripts/estimate-context-size.py before.md after.md --markdown
 ```
 
-Run the helper regression tests before changing file discovery, thresholds, encoding, totals, or output formats:
+Run the helper regression tests before changing file discovery, thresholds, encoding, totals, installer behaviour, or output formats:
 
 ```bash
 python3 -m unittest discover -s tests -p 'test_estimate_context_size.py' -v
 bash tests/test_check_token_hygiene.sh
+sh tests/test_install.sh
 ```
 
-The shell suite verifies staged filenames containing spaces, log and context thresholds, instruction-size limits, untracked-file behavior, and the non-Git fallback. GitHub Actions runs both dependency-free suites on pull requests and pushes to `main`.
+The shell suites verify staged filenames containing spaces, log and context thresholds, instruction-size limits, untracked-file behavior, safe installer overwrite behaviour, nested tool paths, and the non-Git fallback. GitHub Actions runs the dependency-free suites on pull requests and pushes to `main`.
 
 With pre-commit:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+set -eu
+
+BASE_URL="${TOKEN_EFFICIENCY_BASE_URL:-https://raw.githubusercontent.com/ravinperera/ai-token-efficiency-playbook/main}"
+SOURCE_ROOT="${TOKEN_EFFICIENCY_SOURCE_ROOT:-}"
+force=0
+tool=""
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [--force] <codex|claude|gemini|copilot|cursor>
+
+Installs the matching token-efficiency instruction file into the current repository.
+Existing files are never overwritten unless --force is supplied.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --force)
+      force=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$tool" ]; then
+        echo "Only one tool may be selected." >&2
+        usage >&2
+        exit 2
+      fi
+      tool="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$tool" ]; then
+  usage >&2
+  exit 2
+fi
+
+case "$tool" in
+  codex|agents)
+    source_path="AGENTS.md"
+    destination="AGENTS.md"
+    ;;
+  claude)
+    source_path="CLAUDE.md"
+    destination="CLAUDE.md"
+    ;;
+  gemini)
+    source_path="GEMINI.md"
+    destination="GEMINI.md"
+    ;;
+  copilot)
+    source_path=".github/copilot-instructions.md"
+    destination=".github/copilot-instructions.md"
+    ;;
+  cursor)
+    source_path=".cursor/rules/token-efficiency.mdc"
+    destination=".cursor/rules/token-efficiency.mdc"
+    ;;
+  *)
+    echo "Unsupported tool: $tool" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [ -e "$destination" ] && [ "$force" -ne 1 ]; then
+  echo "Refusing to overwrite existing $destination. Re-run with --force to replace it." >&2
+  exit 3
+fi
+
+parent=$(dirname "$destination")
+if [ "$parent" != "." ]; then
+  mkdir -p "$parent"
+fi
+
+if [ -n "$SOURCE_ROOT" ]; then
+  cp "$SOURCE_ROOT/$source_path" "$destination"
+else
+  command -v curl >/dev/null 2>&1 || {
+    echo "curl is required when TOKEN_EFFICIENCY_SOURCE_ROOT is not set." >&2
+    exit 4
+  }
+  tmp="${destination}.tmp.$$"
+  trap 'rm -f "$tmp"' EXIT HUP INT TERM
+  curl -fsSL "$BASE_URL/$source_path" -o "$tmp"
+  mv "$tmp" "$destination"
+  trap - EXIT HUP INT TERM
+fi
+
+echo "Installed $destination for $tool."

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+run_install() {
+  target_dir=$1
+  shift
+  (
+    cd "$target_dir"
+    TOKEN_EFFICIENCY_SOURCE_ROOT="$ROOT" sh "$ROOT/scripts/install.sh" "$@"
+  )
+}
+
+mkdir -p "$TMP/codex"
+run_install "$TMP/codex" codex
+cmp "$ROOT/AGENTS.md" "$TMP/codex/AGENTS.md"
+
+printf 'keep me\n' > "$TMP/codex/AGENTS.md"
+if run_install "$TMP/codex" codex >/dev/null 2>&1; then
+  echo "installer unexpectedly overwrote an existing file without --force" >&2
+  exit 1
+fi
+[ "$(cat "$TMP/codex/AGENTS.md")" = "keep me" ]
+
+run_install "$TMP/codex" --force codex
+cmp "$ROOT/AGENTS.md" "$TMP/codex/AGENTS.md"
+
+mkdir -p "$TMP/copilot"
+run_install "$TMP/copilot" copilot
+cmp "$ROOT/.github/copilot-instructions.md" "$TMP/copilot/.github/copilot-instructions.md"
+
+mkdir -p "$TMP/cursor"
+run_install "$TMP/cursor" cursor
+cmp "$ROOT/.cursor/rules/token-efficiency.mdc" "$TMP/cursor/.cursor/rules/token-efficiency.mdc"
+
+if run_install "$TMP/codex" unknown >/dev/null 2>&1; then
+  echo "installer unexpectedly accepted an unsupported tool" >&2
+  exit 1
+fi
+
+echo "installer tests passed"


### PR DESCRIPTION
## Summary

- add a dependency-free `scripts/install.sh` helper for Codex, Claude, Gemini, Copilot, and Cursor
- refuse to overwrite existing instruction files unless `--force` is supplied
- add offline regression coverage for overwrite protection, nested paths, and unsupported tools
- document the one-command install path in the README

## Validation

Existing helper-script CI now runs the installer regression test alongside the existing dependency-free suites.

Closes #7