### PR TITLE
Add strict missing-input mode to context estimator

### DIFF
--- a/docs/context-size-estimator.md
+++ b/docs/context-size-estimator.md
@@ -30,6 +30,14 @@ Generate a Markdown table for a case study:
 python3 scripts/estimate-context-size.py before.md after.md --markdown
 ```
 
+For CI or repeatable benchmarks, fail rather than silently measuring a partial input set when a requested path is missing:
+
+```bash
+python3 scripts/estimate-context-size.py before.md after.md --fail-on-missing
+```
+
+Without `--fail-on-missing`, the helper keeps its interactive-friendly behaviour: missing paths are warned about and skipped.
+
 ## How to use the numbers
 
 Use the same files, tool, and measurement method before and after the change. Record the result in [`templates/token-savings-measurement.md`](../templates/token-savings-measurement.md).

--- a/scripts/estimate-context-size.py
+++ b/scripts/estimate-context-size.py
@@ -56,7 +56,19 @@ def main() -> int:
         action="store_true",
         help="Print a Markdown table suitable for case studies",
     )
+    parser.add_argument(
+        "--fail-on-missing",
+        action="store_true",
+        help="Return a non-zero exit code if any explicitly requested input path is missing",
+    )
     args = parser.parse_args()
+
+    if args.fail_on_missing:
+        missing_paths = [Path(raw_path) for raw_path in args.paths if not Path(raw_path).exists()]
+        if missing_paths:
+            for path in missing_paths:
+                print(f"error: missing path: {path}", file=sys.stderr)
+            return 2
 
     rows: list[tuple[str, int, int, int, int, int]] = []
     totals = [0, 0, 0, 0, 0]

--- a/tests/test_estimate_context_size.py
+++ b/tests/test_estimate_context_size.py
@@ -99,6 +99,23 @@ class EstimateContextSizeTests(unittest.TestCase):
             result.stdout,
         )
 
+    def test_fail_on_missing_returns_nonzero_without_silent_measurement(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "does-not-exist.md",
+                "--fail-on-missing",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("error: missing path: does-not-exist.md", result.stderr)
+        self.assertNotIn("total:", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add an opt-in `--fail-on-missing` mode for repeatable benchmark and CI use
- preserve the existing warning-and-skip default for ad-hoc use
- add dependency-free regression coverage and usage documentation

## Risk
Low. The default CLI behaviour is unchanged; strict failure is opt-in and affects only the local measurement helper.

Closes #93