### PR TITLE
Run all Python helper tests in CI

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -33,11 +33,11 @@ jobs:
           git fetch --no-tags --depth=1 origin "${REF}"
           git checkout --detach FETCH_HEAD
 
-      - name: Test context-size estimator
+      - name: Run Python helper tests
         run: |
           python3 -m unittest discover \
             -s tests \
-            -p 'test_estimate_context_size.py' \
+            -p 'test_*.py' \
             -v
 
       - name: Test token hygiene checker


### PR DESCRIPTION
## Summary
- discover every `test_*.py` unittest module under `tests/`
- keep the existing shell-based token hygiene and installer tests unchanged
- preserve read-only workflow permissions and dependency-free execution

Closes #97